### PR TITLE
Move `table_node` next logic to `adjacent_node_iterator`

### DIFF
--- a/huffman/BUILD.bazel
+++ b/huffman/BUILD.bazel
@@ -5,6 +5,7 @@ cc_library(
     srcs = [
         "src/bit.hpp",
         "src/code.hpp",
+        "src/detail/base_view.hpp",
         "src/detail/static_vector.hpp",
         "src/detail/table_node.hpp",
         "src/detail/table_storage.hpp",

--- a/huffman/BUILD.bazel
+++ b/huffman/BUILD.bazel
@@ -6,6 +6,7 @@ cc_library(
         "src/bit.hpp",
         "src/code.hpp",
         "src/detail/base_view.hpp",
+        "src/detail/iterator_interface.hpp",
         "src/detail/static_vector.hpp",
         "src/detail/table_node.hpp",
         "src/detail/table_storage.hpp",

--- a/huffman/BUILD.bazel
+++ b/huffman/BUILD.bazel
@@ -6,6 +6,7 @@ cc_library(
         "src/bit.hpp",
         "src/code.hpp",
         "src/detail/base_view.hpp",
+        "src/detail/adjacent_node_iterator.hpp",
         "src/detail/iterator_interface.hpp",
         "src/detail/static_vector.hpp",
         "src/detail/table_node.hpp",

--- a/huffman/src/detail/adjacent_node_iterator.hpp
+++ b/huffman/src/detail/adjacent_node_iterator.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "huffman/src/detail/iterator_interface.hpp"
+
+#include <iterator>
+
+namespace gpu_deflate::huffman::detail {
+
+/// Iterator for a contiguous range of `table_node` values
+///
+/// Allows iteration over a contiguous range of `table_node`, using the value's
+/// `node_size` in order to advance to the next adjacent node.
+///
+/// Given a contiguous container of nodes and an `adjacent_node_iterator` `i`,
+/// `++i` returns an iterator to the next node, using `node_size()` to determine
+/// if `i` is an internal node or a leaf node. If `i` is an internal node, (i.e.
+/// `i` represents a node with children), `++i` skips the appropriate number of
+/// elements in the associated container.
+///
+/// | freq: 3 | freq: 1 | freq: 1 | freq: 4 | freq: 2 |
+/// | ns:   3 | ns:   1 | ns:   1 | ns:   2 | ns:   1 |
+/// ^                             ^
+/// i                             |
+///                               |
+/// ++i --------------------------+
+///
+template <class Node>
+class adjacent_node_iterator
+    : public iterator_interface<adjacent_node_iterator<Node>>
+{
+  Node* base_{};
+
+  friend struct iterator_interface<adjacent_node_iterator>;
+
+  constexpr auto preinc() -> adjacent_node_iterator&
+  {
+    base_ += base_->node_size();
+    return *this;
+  }
+
+public:
+  using base_iterator = Node*;
+
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = Node;
+  using reference = Node&;
+  using pointer = Node*;
+  using difference_type = std::ptrdiff_t;
+
+  adjacent_node_iterator() = default;
+  constexpr explicit adjacent_node_iterator(base_iterator it) : base_{it} {}
+
+  constexpr auto base() const noexcept -> base_iterator { return base_; }
+
+  constexpr auto operator*() const -> reference { return *base_; }
+
+  friend constexpr auto
+  operator<=>(adjacent_node_iterator, adjacent_node_iterator) = default;
+};
+
+}  // namespace gpu_deflate::huffman::detail

--- a/huffman/src/detail/base_view.hpp
+++ b/huffman/src/detail/base_view.hpp
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <concepts>
+#include <iterator>
+#include <ranges>
+#include <utility>
+
+namespace gpu_deflate::huffman::detail {
+
+/// A view of elements cast to a base class
+/// @tparam V underlying view
+/// @tparam B base class
+///
+template <std::ranges::forward_range V, class B>
+  requires std::ranges::view<V> and
+           std::same_as<std::ranges::iterator_t<V>,
+                        std::ranges::sentinel_t<V>> and
+           std::derived_from<std::ranges::range_value_t<V>, B>
+class base_view : public std::ranges::view_interface<base_view<V, B>>
+{
+  // This is largely adapted from `transform_view` (or other views), although we
+  // apply some simplifications:
+  // * V must model `forward_range` instead of `input_range`
+  // * sentinel_t<V> is the same as iterator_t<V>
+  //
+  // https://eel.is/c++draft/range.transform
+
+  V base_{};
+
+public:
+  class iterator
+  {
+    using base_iterator = std::ranges::iterator_t<V>;
+    base_iterator base_{};
+
+  public:
+    using iterator_category =
+        typename std::iterator_traits<base_iterator>::iterator_category;
+    using value_type = std::ranges::range_value_t<V>;
+    using reference = B&;
+    using pointer = B*;
+    using difference_type = std::ranges::range_difference_t<V>;
+
+    iterator()
+      requires std::default_initializable<base_iterator>
+    = default;
+    constexpr iterator(base_iterator current) : base_{std::move(current)} {}
+
+    constexpr auto base() const& noexcept -> const base_iterator&
+    {
+      return base_;
+    }
+    constexpr auto base() && -> base_iterator { return std::move(base_); }
+
+    constexpr auto operator*() const -> reference
+    {
+      return static_cast<reference>(*base_);
+    }
+    constexpr auto operator->() const -> pointer { return &**this; }
+
+    constexpr auto operator++() -> iterator&
+    {
+      ++base_;
+      return *this;
+    }
+    constexpr auto operator++(int) -> iterator
+    {
+      auto tmp = *this;
+      ++*this;
+      return tmp;
+    }
+
+    constexpr auto operator--() -> iterator&
+      requires std::ranges::bidirectional_range<V>
+    {
+      --base_;
+      return *this;
+    }
+    constexpr auto operator--(int) -> iterator
+      requires std::ranges::bidirectional_range<V>
+    {
+      auto tmp = *this;
+      --*this;
+      return tmp;
+    }
+
+    constexpr auto operator+=(difference_type n) -> iterator&
+      requires std::ranges::random_access_range<V>
+    {
+      base_ += n;
+      return *this;
+    }
+    constexpr auto operator-=(difference_type n) -> iterator&
+      requires std::ranges::random_access_range<V>
+    {
+      base_ -= n;
+      return *this;
+    }
+
+    constexpr auto operator[](difference_type n) const -> reference
+      requires std::ranges::random_access_range<V>
+    {
+      return static_cast<reference>(base_[n]);
+    }
+
+    friend constexpr auto
+    operator<=>(const iterator&, const iterator&) = default;
+
+    friend constexpr auto operator+(iterator i, difference_type n) -> iterator
+      requires std::ranges::random_access_range<V>
+    {
+      return i += n;
+    }
+    friend constexpr auto operator+(difference_type n, iterator i) -> iterator
+      requires std::ranges::random_access_range<V>
+    {
+      return i + n;
+    }
+
+    friend constexpr auto operator-(iterator i, difference_type n) -> iterator
+      requires std::ranges::random_access_range<V>
+    {
+      return i -= n;
+    }
+    friend constexpr auto
+    operator-(const iterator& x, const iterator& y) -> difference_type
+      requires std::ranges::random_access_range<V>
+    {
+      return x.base() - y.base();
+    }
+  };
+
+  base_view()
+    requires std::default_initializable<V>
+  = default;
+  constexpr explicit base_view(V base) : base_{std::move(base)} {}
+
+  constexpr auto base() const& -> V
+    requires std::copy_constructible<V>
+  {
+    return base_;
+  }
+  constexpr auto base() && -> V { return std::move(base_); }
+
+  constexpr auto begin() const -> iterator { return {base().begin()}; }
+  constexpr auto end() const -> iterator { return {base().end()}; }
+};
+
+// Use of range_adaptor_clousure requires GCC 13 or LLVM > 16.0.0
+// While this isn't necessary, it does allow a simpler declaration of
+// `base_view_` type in the `table` class template.
+
+// namespace views {
+//
+// template <class B>
+// struct base_raco : std::ranges::range_adaptor_closure<base_raco<B>>
+//{
+//  template <std::ranges::forward_range V>
+//  constexpr auto operator()(V v) const
+//    -> base_view<V, B>
+//  {
+//    return base_view<V, B>{v}
+//  }
+//};
+//
+// template <class B>
+// inline constexpr auto base = base_raco<B>{};
+//
+//}
+
+}  // namespace gpu_deflate::huffman::detail

--- a/huffman/src/detail/base_view.hpp
+++ b/huffman/src/detail/base_view.hpp
@@ -32,10 +32,11 @@ class base_view : public std::ranges::view_interface<base_view<V, B>>
 public:
   class iterator : public iterator_interface<iterator>
   {
-    using base_iterator = std::ranges::iterator_t<V>;
-    base_iterator base_{};
+    std::ranges::iterator_t<V> base_{};
 
   public:
+    using base_iterator = std::ranges::iterator_t<V>;
+
     using iterator_category =
         typename std::iterator_traits<base_iterator>::iterator_category;
     using value_type = std::ranges::range_value_t<V>;

--- a/huffman/src/detail/iterator_interface.hpp
+++ b/huffman/src/detail/iterator_interface.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <concepts>
+#include <iterator>
+
+namespace gpu_deflate::huffman::detail {
+
+/// CRTP helper class used to synthesize operations for a random access iterator
+/// @tparam D derived iterator type
+///
+/// A simplified implementation of `iterator_interface`. This CRTP helper class
+/// synthesizes iterator operations given a basis set of operations. This type
+/// currently requires `D` to implement the following operations:
+/// * operator*() const -> reference
+/// * operator+=(difference_type) -> D&
+/// and the following static member typedefs
+/// * pointer
+/// * reference
+/// * difference_type
+///
+/// Note that `D` must also define the following operations to model
+/// `std::random_access_iterator`
+/// * D()
+/// * operator-(const D&, const D&) -> difference_type
+/// * operator<=>(const D&, const D&)
+/// and static member typedefs
+/// * iterator_category
+/// * value_type
+///
+template <class D>
+struct iterator_interface
+{
+
+  template <class I = D>
+  constexpr auto operator->() const -> typename I::pointer
+  {
+    return &*static_cast<const I&>(*this);
+  }
+
+  template <class I = D>
+  constexpr auto operator++() -> I&
+  {
+    return static_cast<I&>(*this) += typename I::difference_type{1};
+  }
+
+  template <class I = D>
+  constexpr auto operator++(int) -> I
+  {
+    return *this + typename I::difference_type{1};
+  }
+
+  template <class I = D>
+  constexpr auto operator--() -> I&
+  {
+    return *this -= typename I::difference_type{1};
+  }
+
+  template <class I = D>
+  constexpr auto operator--(int) -> I
+  {
+    return *this - typename I::difference_type{1};
+  }
+
+  template <class I = D>
+  constexpr auto operator-=(typename I::difference_type n) -> I&
+  {
+    return static_cast<I&>(*this) += -n;
+  }
+
+
+  template <class I = D>
+  constexpr auto operator[](typename I::difference_type n) const
+    -> typename I::reference
+  {
+    return *(*this + n);
+  }
+
+
+  template <std::same_as<D> I>
+  friend constexpr auto operator+(I i, typename I::difference_type n) -> I
+  {
+    return i += n;
+  }
+
+  template <std::same_as<D> I>
+  friend constexpr auto operator+(typename I::difference_type n, I i) -> I
+  {
+    return i + n;
+  }
+
+  template <std::same_as<D> I>
+  friend constexpr auto operator-(I i, typename I::difference_type n) -> I
+  {
+    return i + -n;
+  }
+
+  /// Default three-way comparison
+  ///
+  // This must be defined to allow three-way comparison for derived class `I` to
+  // be defaulted.
+  friend constexpr auto
+  operator<=>(const iterator_interface&, const iterator_interface&) = default;
+};
+
+}  // namespace gpu_deflate::huffman::detail

--- a/huffman/src/detail/iterator_interface.hpp
+++ b/huffman/src/detail/iterator_interface.hpp
@@ -5,12 +5,42 @@
 
 namespace gpu_deflate::huffman::detail {
 
+// TODO: remove clang-format off after this is merged:
+// https://github.com/llvm/llvm-project/issues/59412
+// clang-format off
+
+template <class D>
+concept _forward_basis = requires (D i, typename D::difference_type n) {
+  { *i } -> std::same_as<typename D::reference>;
+  { i.preinc() } -> std::same_as<D&>;
+};
+
+template <class D>
+concept _random_access_basis = requires (D i, typename D::difference_type n) {
+  { *i } -> std::same_as<typename D::reference>;
+  { i += n } -> std::same_as<D&>;
+};
+
+// clang-format on
+
 /// CRTP helper class used to synthesize operations for a random access iterator
 /// @tparam D derived iterator type
 ///
 /// A simplified implementation of `iterator_interface`. This CRTP helper class
-/// synthesizes iterator operations given a basis set of operations. This type
-/// currently requires `D` to implement the following operations:
+/// synthesizes iterator operations given a basis set of operations. The
+/// synthesized operations are determined by the basis set of operations.
+///
+/// If `D` defines the following operations:
+/// * operator*() const -> reference
+/// * preinc() -> D&
+/// and the following static member typedefs
+/// * pointer
+/// * reference
+/// * difference_type
+/// Then `iterator_interface` will synthesize operations allowing `D` to model
+/// `std::forward_iterator.`
+///
+/// If `D` defines the following operations:
 /// * operator*() const -> reference
 /// * operator+=(difference_type) -> D&
 /// and the following static member typedefs
@@ -18,8 +48,10 @@ namespace gpu_deflate::huffman::detail {
 /// * reference
 /// * difference_type
 ///
-/// Note that `D` must also define the following operations to model
-/// `std::random_access_iterator`
+/// Then `iterator_interface` will synthesize operations allowing `D` to model
+/// `std::random_access_iterator.` Note that `D` must also define the following
+/// operations to model `std::random_access_iterator`, as these operations
+/// cannot be synthesized:
 /// * D()
 /// * operator-(const D&, const D&) -> difference_type
 /// * operator<=>(const D&, const D&)
@@ -32,63 +64,83 @@ struct iterator_interface
 {
 
   template <class I = D>
+    requires (_forward_basis<I> or _random_access_basis<I>)
   constexpr auto operator->() const -> typename I::pointer
   {
     return &*static_cast<const I&>(*this);
   }
 
   template <class I = D>
+    requires _forward_basis<I> or _random_access_basis<I>
   constexpr auto operator++() -> I&
   {
-    return static_cast<I&>(*this) += typename I::difference_type{1};
+    if constexpr (_random_access_basis<I>) {
+      return static_cast<I&>(*this) += typename I::difference_type{1};
+    } else if constexpr (_forward_basis<I>) {
+      return static_cast<I&>(*this).preinc();
+    }
   }
 
   template <class I = D>
+    requires _forward_basis<I> or _random_access_basis<I>
   constexpr auto operator++(int) -> I
   {
-    return *this + typename I::difference_type{1};
+    auto& self = static_cast<I&>(*this);
+
+    auto tmp = self;
+    ++self;
+    return tmp;
   }
 
   template <class I = D>
+    requires _random_access_basis<I>
   constexpr auto operator--() -> I&
   {
     return *this -= typename I::difference_type{1};
   }
 
   template <class I = D>
+    requires _random_access_basis<I>
   constexpr auto operator--(int) -> I
   {
-    return *this - typename I::difference_type{1};
+    auto& self = static_cast<I&>(*this);
+
+    auto tmp = self;
+    --self;
+    return tmp;
   }
 
   template <class I = D>
+    requires _random_access_basis<I>
   constexpr auto operator-=(typename I::difference_type n) -> I&
   {
     return static_cast<I&>(*this) += -n;
   }
 
-
   template <class I = D>
-  constexpr auto operator[](typename I::difference_type n) const
-    -> typename I::reference
+    requires _random_access_basis<I>
+  constexpr auto
+  operator[](typename I::difference_type n) const -> typename I::reference
   {
     return *(*this + n);
   }
 
-
   template <std::same_as<D> I>
+    requires _random_access_basis<I>
   friend constexpr auto operator+(I i, typename I::difference_type n) -> I
   {
     return i += n;
   }
 
   template <std::same_as<D> I>
+    requires _random_access_basis<I>
   friend constexpr auto operator+(typename I::difference_type n, I i) -> I
   {
     return i + n;
   }
 
   template <std::same_as<D> I>
+    requires _random_access_basis<I>
   friend constexpr auto operator-(I i, typename I::difference_type n) -> I
   {
     return i + -n;

--- a/huffman/test/table_find_code_test.cpp
+++ b/huffman/test/table_find_code_test.cpp
@@ -26,46 +26,46 @@ auto main() -> int
   // clang-format on
 
   test("finds code in table") = [] {
-    static_assert('e' == (**table1.find(1_c)).symbol);
-    static_assert('i' == (**table1.find(01_c)).symbol);
-    static_assert('n' == (**table1.find(001_c)).symbol);
-    static_assert('q' == (**table1.find(0001_c)).symbol);
-    static_assert('x' == (**table1.find(00001_c)).symbol);
-    static_assert('\4' == (**table1.find(00000_c)).symbol);
+    static_assert('e' == table1.find(1_c).value()->symbol);
+    static_assert('i' == table1.find(01_c).value()->symbol);
+    static_assert('n' == table1.find(001_c).value()->symbol);
+    static_assert('q' == table1.find(0001_c).value()->symbol);
+    static_assert('x' == table1.find(00001_c).value()->symbol);
+    static_assert('\4' == table1.find(00000_c).value()->symbol);
   };
 
   // bitsize values we compare against are derived from the code
   // NOLINTBEGIN(readability-magic-numbers)
 
   test("code not in table but valid prefix") = [] {
-    static_assert((*table1.find(0_c).error()).symbol == 'i');
-    static_assert((*table1.find(0_c).error()).bitsize() == 2);
+    static_assert(table1.find(0_c).error()->symbol == 'i');
+    static_assert(table1.find(0_c).error()->bitsize() == 2);
 
-    static_assert((*table1.find(00_c).error()).symbol == 'n');
-    static_assert((*table1.find(00_c).error()).bitsize() == 3);
+    static_assert(table1.find(00_c).error()->symbol == 'n');
+    static_assert(table1.find(00_c).error()->bitsize() == 3);
 
-    static_assert((*table1.find(000_c).error()).symbol == 'q');
-    static_assert((*table1.find(000_c).error()).bitsize() == 4);
+    static_assert(table1.find(000_c).error()->symbol == 'q');
+    static_assert(table1.find(000_c).error()->bitsize() == 4);
 
     // ordering of elements with the same bitsize is unspecified
-    static_assert((*table1.find(0000_c).error()).bitsize() == 5);
+    static_assert(table1.find(0000_c).error()->bitsize() == 5);
   };
 
   test("code not in table but valid prefix, using explicit pos") = [] {
     constexpr auto pos1 = table1.find(0_c).error();
-    static_assert((*pos1).symbol == 'i');
-    static_assert((*pos1).bitsize() == 2);
+    static_assert(pos1->symbol == 'i');
+    static_assert(pos1->bitsize() == 2);
 
     constexpr auto pos2 = table1.find(00_c, pos1).error();
-    static_assert((*pos2).symbol == 'n');
-    static_assert((*pos2).bitsize() == 3);
+    static_assert(pos2->symbol == 'n');
+    static_assert(pos2->bitsize() == 3);
 
     constexpr auto pos3 = table1.find(000_c, pos2).error();
-    static_assert((*pos3).symbol == 'q');
-    static_assert((*pos3).bitsize() == 4);
+    static_assert(pos3->symbol == 'q');
+    static_assert(pos3->bitsize() == 4);
 
     // ordering of elements with the same bitsize is unspecified
-    static_assert((*table1.find(0000_c, pos3).error()).bitsize() == 5);
+    static_assert(table1.find(0000_c, pos3).error()->bitsize() == 5);
   };
 
   // NOLINTEND(readability-magic-numbers)


### PR DESCRIPTION
This commit moves the `next()` logic out of `table_node` and into
`detail::adjacent_node_iterator`, allowing use of standard algorithms.

This commit also updates `iterator_interface<D>` to synthesize
operations for either forward iterator or random access iterator. The
synthesized operations are determined from the basis operations of type
`D`.

Change-Id: Ic00e75af2d550b2494a6a664f1b913f18b486714