### PR TITLE
define huffman::table::canonicalize()

### DIFF
--- a/huffman/src/detail/table_storage.hpp
+++ b/huffman/src/detail/table_storage.hpp
@@ -50,6 +50,8 @@ public:
 
   using const_iterator = typename base_type::const_iterator;
 
+  table_storage() = default;
+
   template <class R>
   constexpr table_storage(
       frequency_tag, const R& frequencies, std::optional<symbol_type> eot)

--- a/huffman/test/BUILD.bazel
+++ b/huffman/test/BUILD.bazel
@@ -31,6 +31,16 @@ cc_test(
 )
 
 cc_test(
+    name = "table_canonicalize_test",
+    timeout = "short",
+    srcs = ["table_canonicalize_test.cpp"],
+    deps = [
+        "//huffman",
+        "@boost_ut",
+    ],
+)
+
+cc_test(
     name = "table_from_data_test",
     timeout = "short",
     srcs = ["table_from_data_test.cpp"],

--- a/huffman/test/table_canonicalize_test.cpp
+++ b/huffman/test/table_canonicalize_test.cpp
@@ -1,0 +1,106 @@
+#include "huffman/huffman.hpp"
+
+#include <boost/ut.hpp>
+
+#include <algorithm>
+#include <utility>
+
+auto main() -> int
+{
+  using ::boost::ut::expect;
+  using ::boost::ut::test;
+
+  namespace huffman = ::starflate::huffman;
+  using namespace huffman::literals;
+
+  test("table with DEFLATE canonical code, example 1") = [] {
+    static constexpr auto actual =  // clang-format off
+      huffman::table{
+        huffman::table_contents,
+        {std::pair{010_c, 'D'},
+                  {011_c, 'C'},
+                  {00_c,  'A'},
+                  {1_c,   'B'}}}.canonicalize();
+    // clang-format on
+
+    static constexpr auto expected =  // clang-format off
+      huffman::table{
+        huffman::table_contents,
+        {std::pair{111_c, 'D'},
+                  {110_c, 'C'},
+                  {10_c,  'A'},
+                  {0_c,   'B'}}};
+    // clang-format on
+
+    expect(std::ranges::equal(actual, expected));
+  };
+
+  test("table with DEFLATE canonical code, example 2") = [] {
+    // NOTE: t1 is an *invalid* table (as initially specified) because
+    // some codes are prefixes of others.
+    static constexpr auto actual =  // clang-format off
+      huffman::table{
+        huffman::table_contents,
+        {std::pair{1111_c,  'H'},
+                  {0111_c,  'G'},
+                  {100_c,   'E'},
+                  {011_c,   'D'},
+                  {010_c,   'C'},
+                  {001_c,   'B'},
+                  {000_c,   'A'},
+                  {11_c,    'F'}}}.canonicalize();
+    // clang-format on
+
+    static constexpr auto expected =  // clang-format off
+      huffman::table{
+        huffman::table_contents,
+        {std::pair{1111_c,  'H'},
+                  {1110_c,  'G'},
+                  {110_c,   'E'},
+                  {101_c,   'D'},
+                  {100_c,   'C'},
+                  {011_c,   'B'},
+                  {010_c,   'A'},
+                  {00_c,    'F'}}};
+    // clang-format on
+
+    expect(std::ranges::equal(actual, expected));
+  };
+
+  test("canonicalization is idempotent") = [] {
+    static constexpr auto t1 =  // clang-format off
+      huffman::table{
+        huffman::table_contents,
+        {std::pair{1111_c,  'H'},
+                  {1110_c,  'G'},
+                  {110_c,   'E'},
+                  {101_c,   'D'},
+                  {100_c,   'C'},
+                  {011_c,   'B'},
+                  {010_c,   'A'},
+                  {00_c,    'F'}}};
+    // clang-format on
+
+    auto t2 = t1;
+    t2.canonicalize();
+
+    expect(std::ranges::equal(t1, t2));
+    expect(std::ranges::equal(t1, t2.canonicalize()));
+  };
+
+  test("canonicalize invocable on empty table") = [] {
+    static constexpr auto actual = huffman::table<char, 0>{}.canonicalize();
+    auto expected = huffman::table<char, 0>{};
+
+    expect(std::ranges::equal(actual, expected)) << actual << '\n' << expected;
+  };
+
+  test("canonicalize invocable on single element table") = [] {
+    static constexpr auto actual = huffman::table{
+        huffman::table_contents,
+        {std::pair{0_c, 'A'}}}.canonicalize();
+    auto expected = huffman::table<char, 1>{std::array{'A'}, std::nullopt};
+
+    expect(std::ranges::equal(actual, expected)) << actual << '\n' << expected;
+  };
+}


### PR DESCRIPTION
huffman::table::canonicalize() updates the existing codes in a table to
canonical form for DEFLATE:
 * All codes of a given bit length have lexicographically consecutive
   values, in the same order as the symbols they represent;
 * Shorter codes lexicographically precede longer codes.

Change-Id: Idc3dceefe1b5d17a54f1dab29155a499c7e1d138