### PR TITLE
use skip fields in table::find

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,9 +19,6 @@ Checks: >
     # short names are fine for short lifetimes,
     -readability-identifier-length,
 
-    # allow bool conversions like `int x = 1; if (x)`,
-    -readability-implicit-bool-conversion,
-
     # allow unused variables to be unnamed,
     -readability-named-parameter,
 
@@ -59,6 +56,10 @@ CheckOptions:
       value: true
     - key: performance-move-const-arg.CheckTriviallyCopyableMove
       value: false
+    - key: readability-implicit-bool-conversion.AllowIntegerConditions
+      value : true
+    - key: readability-implicit-bool-conversion.AllowPointerConditions
+      value : true
 
 # only lint files coming from this project
 HeaderFilterRegex: '__main__/'


### PR DESCRIPTION
Replace the frequency and node size fields of table node with a union of
an initialization struct and a decode struct. The initialization struct
contains the previously defined frequency and node size fields and is
used during table construction. The decode struct contains a single skip
value field.

table::find now uses the skip value if the iterator's element bitsize
does not match the code bitsize. This performs a skip to the next group
of elements with a larger bitsize instead of linear traversal of
elements.

Use of a union ensures that skip fields are set after construction as
constant expression context does not allow access to an inactive union
member. This allows re-use of the space without any risk of conflict,
since the skip fields are only used after construction and the frequency
and node size are only used during construction.

Change-Id: If703d0b0a6307ebcf9e64722431069247ba51800