### PR TITLE
store huffman table elements in forward order

### DIFF
--- a/huffman/src/detail/static_vector.hpp
+++ b/huffman/src/detail/static_vector.hpp
@@ -79,6 +79,7 @@ public:
   }
 
   constexpr auto size() const noexcept -> size_type { return size_; }
+  constexpr auto empty() const noexcept -> size_type { return not size(); }
 
   constexpr auto end() noexcept -> iterator { return begin() + size(); }
   constexpr auto end() const noexcept -> const_iterator

--- a/huffman/src/detail/table_storage.hpp
+++ b/huffman/src/detail/table_storage.hpp
@@ -117,8 +117,6 @@ public:
       ++it;
     }
 
-    std::ranges::sort(*this, std::ranges::greater{}, as_code);
-
     assert(std::ranges::unique(*this, {}, as_code).empty());
     assert(std::ranges::unique(*this, {}, as_symbol).empty());
   }
@@ -127,6 +125,7 @@ public:
   using base_type::cbegin;
   using base_type::cend;
   using base_type::data;
+  using base_type::empty;
   using base_type::end;
   using base_type::front;
   using base_type::size;

--- a/huffman/test/decode_test.cpp
+++ b/huffman/test/decode_test.cpp
@@ -3,11 +3,9 @@
 #include <boost/ut.hpp>
 
 #include <array>
-#include <climits>
 #include <cstddef>
 #include <stdexcept>
 #include <utility>
-#include <vector>
 
 auto main() -> int
 {
@@ -19,7 +17,7 @@ auto main() -> int
 
   test("basic") = [] {
     // encoded data from dahuffman readme.rst, but in hex.
-    constexpr std::array<std::byte, 6> encoded_bytes = {
+    constexpr std::array encoded_bytes = {
         std::byte{0x86},
         std::byte{0x7c},
         std::byte{0x25},
@@ -31,12 +29,12 @@ auto main() -> int
     static constexpr auto code_table =  // clang-format off
       huffman::table{
         huffman::table_contents,
-        {std::pair{00000_c, eot},
-                  {00001_c, 'x'},
-                  {0001_c,  'q'},
-                  {001_c,   'n'},
+        {std::pair{1_c,     'e'},
                   {01_c,    'i'},
-                  {1_c,     'e'}}
+                  {001_c,   'n'},
+                  {0001_c,  'q'},
+                  {00001_c, 'x'},
+                  {00000_c, eot}}
       };  // clang-format on
 
     constexpr std::array expected = {

--- a/huffman/test/table_canonicalize_test.cpp
+++ b/huffman/test/table_canonicalize_test.cpp
@@ -17,19 +17,19 @@ auto main() -> int
     static constexpr auto actual =  // clang-format off
       huffman::table{
         huffman::table_contents,
-        {std::pair{010_c, 'D'},
+        {std::pair{00_c,  'A'},
+                  {1_c,   'B'},
                   {011_c, 'C'},
-                  {00_c,  'A'},
-                  {1_c,   'B'}}}.canonicalize();
+                  {010_c, 'D'}}}.canonicalize();
     // clang-format on
 
     static constexpr auto expected =  // clang-format off
       huffman::table{
         huffman::table_contents,
-        {std::pair{111_c, 'D'},
-                  {110_c, 'C'},
+        {std::pair{0_c,   'B'},
                   {10_c,  'A'},
-                  {0_c,   'B'}}};
+                  {110_c, 'C'},
+                  {111_c, 'D'}}};
     // clang-format on
 
     expect(std::ranges::equal(actual, expected));
@@ -41,27 +41,27 @@ auto main() -> int
     static constexpr auto actual =  // clang-format off
       huffman::table{
         huffman::table_contents,
-        {std::pair{1111_c,  'H'},
-                  {0111_c,  'G'},
-                  {100_c,   'E'},
-                  {011_c,   'D'},
-                  {010_c,   'C'},
+        {std::pair{000_c,   'A'},
                   {001_c,   'B'},
-                  {000_c,   'A'},
-                  {11_c,    'F'}}}.canonicalize();
+                  {010_c,   'C'},
+                  {011_c,   'D'},
+                  {100_c,   'E'},
+                  {11_c,    'F'},
+                  {0111_c,  'G'},
+                  {1111_c,  'H'}}}.canonicalize();
     // clang-format on
 
     static constexpr auto expected =  // clang-format off
       huffman::table{
         huffman::table_contents,
-        {std::pair{1111_c,  'H'},
-                  {1110_c,  'G'},
-                  {110_c,   'E'},
-                  {101_c,   'D'},
-                  {100_c,   'C'},
-                  {011_c,   'B'},
+        {std::pair{00_c,    'F'},
                   {010_c,   'A'},
-                  {00_c,    'F'}}};
+                  {011_c,   'B'},
+                  {100_c,   'C'},
+                  {101_c,   'D'},
+                  {110_c,   'E'},
+                  {1110_c,  'G'},
+                  {1111_c,  'H'}}};
     // clang-format on
 
     expect(std::ranges::equal(actual, expected));
@@ -71,14 +71,14 @@ auto main() -> int
     static constexpr auto t1 =  // clang-format off
       huffman::table{
         huffman::table_contents,
-        {std::pair{1111_c,  'H'},
-                  {1110_c,  'G'},
-                  {110_c,   'E'},
-                  {101_c,   'D'},
-                  {100_c,   'C'},
-                  {011_c,   'B'},
+        {std::pair{00_c,    'F'},
                   {010_c,   'A'},
-                  {00_c,    'F'}}};
+                  {011_c,   'B'},
+                  {100_c,   'C'},
+                  {101_c,   'D'},
+                  {110_c,   'E'},
+                  {1110_c,  'G'},
+                  {1111_c,  'H'}}};
     // clang-format on
 
     auto t2 = t1;

--- a/huffman/test/table_find_code_test.cpp
+++ b/huffman/test/table_find_code_test.cpp
@@ -16,12 +16,12 @@ auto main() -> int
   static constexpr auto table1 =  // clang-format off
     huffman::table{
     huffman::table_contents,
-    {std::pair{00000_c, '\4'},
-              {00001_c, 'x'},
-              {0001_c,  'q'},
-              {001_c,   'n'},
+    {std::pair{1_c,     'e'},
               {01_c,    'i'},
-              {1_c,     'e'}}
+              {001_c,   'n'},
+              {0001_c,  'q'},
+              {00001_c, 'x'},
+              {00000_c, '\4'}}
   };
   // clang-format on
 
@@ -78,12 +78,12 @@ auto main() -> int
     static constexpr auto table =  // clang-format off
       huffman::table{
       huffman::table_contents,
-      {std::pair{00000_c, '\4'},
-       {00001_c, 'x'},
-       {0001_c,  'q'},
-       {001_c,   'n'},
-       {01_c,    'i'},
-       {11_c,     'e'}}
+      {std::pair{11_c,     'e'},
+                {01_c,    'i'},
+                {001_c,   'n'},
+                {0001_c,  'q'},
+                {00001_c, 'x'},
+                {00000_c, '\4'}}
     };
     // clang-format on
 

--- a/huffman/test/table_from_contents_test.cpp
+++ b/huffman/test/table_from_contents_test.cpp
@@ -18,13 +18,15 @@ auto main() -> int
 
   test("code table constructible from code-symbol mapping") = [] {
     const auto t = huffman::table<char>{
+        // clang-format off
         huffman::table_contents,
-        {{00000_c, '\4'},
-         {00001_c, 'x'},
-         {0001_c, 'q'},
-         {001_c, 'n'},
+        {{1_c, 'e'},
          {01_c, 'i'},
-         {1_c, 'e'}}};
+         {001_c, 'n'},
+         {0001_c, 'q'},
+         {00001_c, 'x'},
+         {00000_c, '\4'}}};
+    // clang-format on
 
     auto ss = std::stringstream{};
     ss << t;
@@ -35,8 +37,8 @@ auto main() -> int
         "2\t01\t1\t`i`\n"
         "3\t001\t1\t`n`\n"
         "4\t0001\t1\t`q`\n"
-        "5\t00000\t0\t`\4`\n"
-        "5\t00001\t1\t`x`\n";
+        "5\t00001\t1\t`x`\n"
+        "5\t00000\t0\t`\4`\n";
 
     expect(table == ss.str()) << ss.str();
   };
@@ -47,26 +49,24 @@ auto main() -> int
     const auto t1 =  // clang-format off
       huffman::table<char>{
         huffman::table_contents,
-        {{00000_c, '\4'},
-         {00001_c, 'x'},
-         {0001_c,  'q'},
-         {001_c,   'n'},
+        {{1_c,     'e'},
          {01_c,    'i'},
-         {1_c,     'e'}}
-      };
+         {001_c,   'n'},
+         {0001_c,  'q'},
+         {00001_c, 'x'},
+         {00000_c, '\4'}}};
     // clang-format on
 
     const auto t2 =  // clang-format off
       huffman::table<char>{
         huffman::table_contents,
         std::vector{
-            std::tuple{00000_c, '\4'},
-                      {00001_c, 'x'},
-                      {0001_c,  'q'},
-                      {001_c,   'n'},
+            std::tuple{1_c,     'e'},
                       {01_c,    'i'},
-                      {1_c,     'e'}}
-      };
+                      {001_c,   'n'},
+                      {0001_c,  'q'},
+                      {00001_c, 'x'},
+                      {00000_c, '\4'}}};
     // clang-format on
 
     expect(std::ranges::equal(t1, t2));
@@ -77,26 +77,24 @@ auto main() -> int
     const auto t1 =  // clang-format off
       huffman::table{
         huffman::table_contents,
-        {std::pair{00000_c, '\4'},
-                  {00001_c, 'x'},
-                  {0001_c,  'q'},
-                  {001_c,   'n'},
+        {std::pair{1_c,     'e'},
                   {01_c,    'i'},
-                  {1_c,     'e'}}
-      };
+                  {001_c,   'n'},
+                  {0001_c,  'q'},
+                  {00001_c, 'x'},
+                  {00000_c, '\4'}}};
     // clang-format on
 
     const auto t2 =  // clang-format off
       huffman::table{
         huffman::table_contents,
         std::vector{
-            std::tuple{00000_c, '\4'},
-                      {00001_c, 'x'},
-                      {0001_c,  'q'},
-                      {001_c,   'n'},
+            std::tuple{1_c,     'e'},
                       {01_c,    'i'},
-                      {1_c,     'e'}}
-      };
+                      {001_c,   'n'},
+                      {0001_c,  'q'},
+                      {00001_c, 'x'},
+                      {00000_c, '\4'}}};
       // clang-format off
 
     expect(std::ranges::equal(t1, t2));
@@ -106,25 +104,23 @@ auto main() -> int
     static constexpr auto t1 = // clang-format off
       huffman::table{
         huffman::table_contents,
-        {std::pair{00000_c, '\4'},
-                  {00001_c, 'x'},
-                  {0001_c,  'q'},
-                  {001_c,   'n'},
+        {std::pair{1_c,     'e'},
                   {01_c,    'i'},
-                  {1_c,     'e'}}
-      };
+                  {001_c,   'n'},
+                  {0001_c,  'q'},
+                  {00001_c, 'x'},
+                  {00000_c, '\4'}}};
     // clang-format on
 
     static constexpr auto t2 =  // clang-format off
         huffman::table<char, 6>{
           huffman::table_contents,
-          {{00000_c, '\4'},
-           {00001_c, 'x'},
-           {0001_c,  'q'},
-           {001_c,   'n'},
+          {{1_c,     'e'},
            {01_c,    'i'},
-           {1_c,     'e'}}
-        };
+           {001_c,   'n'},
+           {0001_c,  'q'},
+           {00001_c, 'x'},
+           {00000_c, '\4'}}};
     // clang-format on
 
     expect(std::ranges::equal(t1, t2));
@@ -134,13 +130,13 @@ auto main() -> int
     expect(aborts([] {  // clang-format off
       huffman::table{
           huffman::table_contents,
-          {std::pair{00000_c, '\4'},
-                    {00001_c, 'x'},
-                    {0001_c,  'q'},
-                    {0001_c,  'g'},
-                    {001_c,   'n'},
+          {std::pair{1_c,     'e'},
                     {01_c,    'i'},
-                    {1_c,     'e'}}};
+                    {001_c,   'n'},
+                    {0001_c,  'g'},
+                    {0001_c,  'q'},
+                    {00001_c, 'x'},
+                    {00000_c, '\4'}}};
       // clang-format on
     }));
   };
@@ -149,13 +145,13 @@ auto main() -> int
     expect(aborts([] {  // clang-format off
       huffman::table{
           huffman::table_contents,
-          {std::pair{00000_c, '\4'},
-                    {00001_c, 'x'},
-                    {0001_c,  'q'},
-                    {0000_c,  'q'},
-                    {001_c,   'n'},
+          {std::pair{1_c,     'e'},
                     {01_c,    'i'},
-                    {1_c,     'e'}}};
+                    {001_c,   'n'},
+                    {0000_c,  'q'},
+                    {0001_c,  'q'},
+                    {00001_c, 'x'},
+                    {00000_c, '\4'}}};
       // clang-format on
     }));
   };

--- a/huffman/test/table_from_data_test.cpp
+++ b/huffman/test/table_from_data_test.cpp
@@ -83,6 +83,23 @@ auto main() -> int
 
     expect(std::ranges::equal(t1, t2));
   };
+
+  test("empty code table") = [] {
+    const auto zero = huffman::table<char, 0>{};
+
+    expect(zero.begin() == zero.end());
+  };
+
+  test("one symbol code table") = [] {
+    using namespace std::literals;
+
+    constexpr auto data = "a"sv;
+
+    const auto one = huffman::table<char, 1>{data};
+
+    expect('a' == one.begin()->symbol);
+    expect(1 == one.begin()->bitsize());
+  };
 }
 
 // NOLINTEND(readability-magic-numbers,google-build-using-namespace)


### PR DESCRIPTION
Remove use of std::reverse_iterator when iterating over table elements.
Instead, invoke reverse on the underlying table storage after
construction.

Change-Id: I45916a591f51298fff8b4012b9507b781021100e