### PR TITLE
add huffman table constructor from symbol-bitsize range

### DIFF
--- a/huffman/BUILD.bazel
+++ b/huffman/BUILD.bazel
@@ -14,6 +14,7 @@ cc_library(
         "src/detail/table_storage.hpp",
         "src/encoding.hpp",
         "src/table.hpp",
+        "src/utility.hpp",
     ],
     hdrs = ["huffman.hpp"],
     visibility = ["//:__subpackages__"],

--- a/huffman/src/detail/table_storage.hpp
+++ b/huffman/src/detail/table_storage.hpp
@@ -3,6 +3,7 @@
 #include "huffman/src/code.hpp"
 #include "huffman/src/detail/static_vector.hpp"
 #include "huffman/src/encoding.hpp"
+#include "huffman/src/utility.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -13,18 +14,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace starflate::huffman {
-
-/// Disambiguation tag to specify a table is constructed with a code-symbol
-///    mapping
-///
-struct table_contents_tag
-{
-  explicit table_contents_tag() = default;
-};
-inline constexpr auto table_contents = table_contents_tag{};
-
-namespace detail {
+namespace starflate::huffman::detail {
 
 struct frequency_tag
 {
@@ -55,7 +45,6 @@ public:
   template <class R>
   constexpr table_storage(
       frequency_tag, const R& frequencies, std::optional<symbol_type> eot)
-      : base_type{}
   {
     base_type::reserve(
         std::ranges::size(frequencies) + std::size_t{eot.has_value()});
@@ -74,7 +63,6 @@ public:
   template <class R>
   constexpr table_storage(
       data_tag, const R& data, std::optional<symbol_type> eot)
-      : base_type{}
   {
     if (eot) {
       base_type::emplace_back(*eot, 1UZ);
@@ -97,7 +85,7 @@ public:
   }
 
   template <class R>
-  constexpr table_storage(table_contents_tag, const R& map) : base_type{}
+  constexpr table_storage(table_contents_tag, const R& map)
   {
     const auto as_code = [](auto& node) -> auto& {
       return static_cast<code&>(node);
@@ -116,9 +104,6 @@ public:
       as_symbol(*it) = s;
       ++it;
     }
-
-    assert(std::ranges::unique(*this, {}, as_code).empty());
-    assert(std::ranges::unique(*this, {}, as_symbol).empty());
   }
 
   using base_type::begin;
@@ -131,5 +116,4 @@ public:
   using base_type::size;
 };
 
-}  // namespace detail
-}  // namespace starflate::huffman
+}  // namespace starflate::huffman::detail

--- a/huffman/src/utility.hpp
+++ b/huffman/src/utility.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstddef>
+
+namespace starflate::huffman {
+
+/// Convenience alias for a C-style array
+///
+template <class T, std::size_t N>
+using c_array = T[N];
+
+/// Disambiguation tag to specify a table is constructed with a code-symbol
+///    mapping
+///
+struct table_contents_tag
+{
+  explicit table_contents_tag() = default;
+};
+inline constexpr auto table_contents = table_contents_tag{};
+
+/// Disambiguation tag to specify a table is constructed with a symbol-bitsize
+///    mapping
+///
+struct symbol_bitsize_tag
+{
+  explicit symbol_bitsize_tag() = default;
+};
+inline constexpr auto symbol_bitsize = symbol_bitsize_tag{};
+
+}  // namespace starflate::huffman

--- a/huffman/test/BUILD.bazel
+++ b/huffman/test/BUILD.bazel
@@ -21,9 +21,9 @@ cc_test(
 )
 
 cc_test(
-    name = "table_from_frequencies_test",
+    name = "table_canonicalize_test",
     timeout = "short",
-    srcs = ["table_from_frequencies_test.cpp"],
+    srcs = ["table_canonicalize_test.cpp"],
     deps = [
         "//huffman",
         "@boost_ut",
@@ -31,9 +31,19 @@ cc_test(
 )
 
 cc_test(
-    name = "table_canonicalize_test",
+    name = "table_find_code_test",
     timeout = "short",
-    srcs = ["table_canonicalize_test.cpp"],
+    srcs = ["table_find_code_test.cpp"],
+    deps = [
+        "//huffman",
+        "@boost_ut",
+    ],
+)
+
+cc_test(
+    name = "table_from_frequencies_test",
+    timeout = "short",
+    srcs = ["table_from_frequencies_test.cpp"],
     deps = [
         "//huffman",
         "@boost_ut",
@@ -61,9 +71,9 @@ cc_test(
 )
 
 cc_test(
-    name = "table_find_code_test",
+    name = "table_from_symbol_bitsize_test",
     timeout = "short",
-    srcs = ["table_find_code_test.cpp"],
+    srcs = ["table_from_symbol_bitsize_test.cpp"],
     deps = [
         "//huffman",
         "@boost_ut",

--- a/huffman/test/table_from_contents_test.cpp
+++ b/huffman/test/table_from_contents_test.cpp
@@ -125,34 +125,4 @@ auto main() -> int
 
     expect(std::ranges::equal(t1, t2));
   };
-
-  test("code table aborts on duplicate codes") = [] {
-    expect(aborts([] {  // clang-format off
-      huffman::table{
-          huffman::table_contents,
-          {std::pair{1_c,     'e'},
-                    {01_c,    'i'},
-                    {001_c,   'n'},
-                    {0001_c,  'g'},
-                    {0001_c,  'q'},
-                    {00001_c, 'x'},
-                    {00000_c, '\4'}}};
-      // clang-format on
-    }));
-  };
-
-  test("code table aborts on duplicate symbols") = [] {
-    expect(aborts([] {  // clang-format off
-      huffman::table{
-          huffman::table_contents,
-          {std::pair{1_c,     'e'},
-                    {01_c,    'i'},
-                    {001_c,   'n'},
-                    {0000_c,  'q'},
-                    {0001_c,  'q'},
-                    {00001_c, 'x'},
-                    {00000_c, '\4'}}};
-      // clang-format on
-    }));
-  };
 }

--- a/huffman/test/table_from_symbol_bitsize_test.cpp
+++ b/huffman/test/table_from_symbol_bitsize_test.cpp
@@ -1,0 +1,71 @@
+#include "huffman/huffman.hpp"
+
+#include <boost/ut.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+auto main() -> int
+{
+  using ::boost::ut::expect;
+  using ::boost::ut::test;
+
+  namespace huffman = ::starflate::huffman;
+  using namespace huffman::literals;
+
+  test("table with DEFLATE canonical code, RFC example 1") = [] {
+    // https://datatracker.ietf.org/doc/html/rfc1951#page-9
+    static constexpr auto actual =  // clang-format off
+      huffman::table{
+        huffman::symbol_bitsize,
+        {std::pair{'A', 2},
+                  {'B', 1},
+                  {'C', 3},
+                  {'D', 3}}};
+    // clang-format on
+
+    static constexpr auto expected =  // clang-format off
+      huffman::table{
+        huffman::table_contents,
+        {std::pair{0_c,   'B'},
+                  {10_c,  'A'},
+                  {110_c, 'C'},
+                  {111_c, 'D'}}};
+    // clang-format on
+
+    static_assert(std::ranges::equal(actual, expected));
+  };
+
+  test("table with DEFLATE canonical code, RFC example 2") = [] {
+    // https://datatracker.ietf.org/doc/html/rfc1951#page-9
+    const auto actual =  // clang-format off
+      huffman::table{
+        huffman::symbol_bitsize,
+        std::vector<std::pair<char, std::uint8_t>>{{'A', 3},
+                                                   {'B', 3},
+                                                   {'C', 3},
+                                                   {'D', 3},
+                                                   {'E', 3},
+                                                   {'F', 2},
+                                                   {'G', 4},
+                                                   {'H', 4}}};
+    // clang-format on
+
+    static constexpr auto expected =  // clang-format off
+      huffman::table{
+        huffman::table_contents,
+        {std::pair{00_c,    'F'},
+                  {010_c,   'A'},
+                  {011_c,   'B'},
+                  {100_c,   'C'},
+                  {101_c,   'D'},
+                  {110_c,   'E'},
+                  {1110_c,  'G'},
+                  {1111_c,  'H'}}};
+    // clang-format on
+
+    expect(std::ranges::equal(actual, expected));
+  };
+}


### PR DESCRIPTION
Add a constructor to huffman::table that takes a range of symbol-bitsize
tuples.

This commit also moves public tag types into a utility header.

Change-Id: Ia125173ce91e2e189c23de0956d9eaa7aa51762c