### PR TITLE
update clang to 17.0.2

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,6 +36,7 @@ Checks: >
 
     # false positive with spaceship operator,
     # https://reviews.llvm.org/D95714?id=320393,
+    # NOTE: still false positive with LLVM 17.0.2,
     -modernize-use-nullptr,
 
     # disable common aliases,
@@ -50,6 +51,9 @@ Checks: >
     -readability-identifier-naming,
     -misc-confusable-identifiers,
 
+    # too many false positives,
+    -misc-include-cleaner,
+
 CheckOptions:
     - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
       value: true
@@ -59,10 +63,5 @@ CheckOptions:
 # only lint files coming from this project
 HeaderFilterRegex: '__main__/'
 
-# clang-diagnostic-builtin-macro-redefined must be manually suppressed here
-# https://github.com/erenon/bazel_clang_tidy/issues/29
-# https://github.com/llvm/llvm-project/issues/56709
-#
-WarningsAsErrors: '*,-clang-diagnostic-builtin-macro-redefined'
-
+WarningsAsErrors: '*'
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -68,11 +68,11 @@ bootlin_toolchain(
     libc_impl = "glibc",
 )
 
-BAZEL_TOOLCHAIN_VERSION = "c65ef7a45907016a754e5bf5bfabac76eb702fd3"
+BAZEL_TOOLCHAIN_VERSION = "a76d197a47ad7dbfc9374ccd5691cb4ebd985607"
 
 http_archive(
     name = "bazel_toolchain",
-    sha256 = "c70777b0aa877085323aa1ced3b6e011811a9800092e837043aa5f678d838301",
+    sha256 = "dcb4552eccfdaae1915153a676a36d9d861a9809065c6de5816cc0ea1d7e0479",
     strip_prefix = "bazel-toolchain-%s" % BAZEL_TOOLCHAIN_VERSION,
     url = "https://github.com/grailbio/bazel-toolchain/archive/%s.tar.gz" % BAZEL_TOOLCHAIN_VERSION,
 )
@@ -88,7 +88,7 @@ llvm_toolchain(
     cxx_flags = {
         "": [
             "-stdlib=libc++",
-            "-std=c++2b",
+            "-std=c++23",
             "-Wshadow",
         ] + COMMON_CXX_FLAGS + COMMON_CXX_WARNINGS + LLVM_COLOR_FLAGS,
     },
@@ -100,7 +100,7 @@ llvm_toolchain(
         "": ["-fsanitize-link-c++-runtime"],
     },
     linux_x86_64_sysroot = "@gcc_toolchain_files//x86_64-buildroot-linux-gnu/sysroot",
-    llvm_version = "16.0.4",
+    llvm_version = "17.0.2",
 )
 
 # register llvm first, it has better error messages

--- a/huffman/src/bit_span.hpp
+++ b/huffman/src/bit_span.hpp
@@ -95,10 +95,13 @@ public:
     requires std::ranges::borrowed_range<R>
   // TODO: remove cppcoreguidelines-pro-type-member-init once
   // https://reviews.llvm.org/D157367 in our toolchain.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,bugprone-forwarding-reference-overload)
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
+  // lack of forward is intentional as we constrain on borrowed_range
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload,cppcoreguidelines-missing-std-forward)
   constexpr bit_span(R&& r)
       : bit_span(std::ranges::data(r), std::ranges::size(r) * CHAR_BIT)
   {}
+  // NOLINTEND(cppcoreguidelines-pro-type-member-init)
 
   [[nodiscard]]
   constexpr auto begin() const -> iterator

--- a/huffman/src/code.hpp
+++ b/huffman/src/code.hpp
@@ -2,6 +2,7 @@
 
 #include "huffman/src/bit.hpp"
 
+#include <bit>
 #include <cassert>
 #include <climits>
 #include <concepts>
@@ -35,10 +36,8 @@ public:
     // NOLINTNEXTLINE(readability-magic-numbers)
     static_assert(CHAR_BIT == 8U, "everything assumes 8 bits per byte");
 
-    // TODO: use std::countl_zero when available in GCC and Clang.
-    // https://en.cppreference.com/w/cpp/numeric/countl_zero
     [[maybe_unused]] const auto msb =
-        64UZ - (value ? std::size_t(__builtin_clzll(value)) : 64UZ);
+        64UZ - static_cast<std::size_t>(std::countl_zero(value));
     assert(msb <= std::size_t{bitsize} and "`value` exceeds `bitsize`");
   }
 


### PR DESCRIPTION
Update LLVM toolchain to 17.0.2 and resolve related TODOs.

Release notes for libc++ can be found here:
https://libcxx.llvm.org/ReleaseNotes/17.html

Change-Id: Idd5c68bb5f64285d379ed0c69a5022a79b5ab339