### PR TITLE
bazelrc: set --incompatible_strict_action_env

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,3 +25,7 @@ build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_toolchain//:c
 try-import %workspace%/user.bazelrc
 
 build --workspace_status_command=tools/bazel_workspace_status.sh
+# Do not load LD_LIBRARY_PATH from the environment. This leads to more cache hits
+# when triggering builds using different shells on the same machine.
+# https://stackoverflow.com/questions/74881594/bazel-builds-from-scratch-ignoring-cache
+build --incompatible_strict_action_env


### PR DESCRIPTION
bazelrc: set --incompatible_strict_action_env

This keeps builds cache-compatible between different shells
(in particular the shell used by the VS Code build task and my
regular ZSH).

Change-Id: Ie854b618bc50e5ca668e0d0faa529a3737346510