### PR TITLE
add `boost::ut::range_eq`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_clang_format//:defs.bzl", "clang_format_update")
 load("@bazel_clang_tidy//:defs.bzl", "clang_tidy_apply_fixes")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -39,4 +40,12 @@ buildifier(
     name = "buildifier.fix",
     lint_mode = "warn",
     mode = "fix",
+)
+
+cc_library(
+    name = "boost_ut",
+    hdrs = ["ut.hpp"],
+    include_prefix = "boost",
+    visibility = ["//:__subpackages__"],
+    deps = ["@boost_ut"],
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -142,7 +142,7 @@ register_toolchains(
     "@gcc_toolchain//:toolchain",
 )
 
-BOOST_UT_VERSION = "2.0.0"
+BOOST_UT_VERSION = "20f2c3f811e25b8c398c6e98545dbf07d72eb4e8"
 
 http_archive(
     name = "boost_ut",
@@ -152,13 +152,13 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "boost_ut",
     hdrs = ["include/boost/ut.hpp"],
-    includes = ["include"],
+    includes = ["."],
     visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "8b5b11197d1308dfc1fe20efd6a656e0c833dbec2807e2292967f6e2f7c0420f",
+    sha256 = "b5a4f3f1f88f3fb375370a734ab7b6b6c7b4f23e82f949544e61f64ebdb1f8dd",
     strip_prefix = "ut-%s" % BOOST_UT_VERSION,
-    url = "https://github.com/boost-ext/ut/archive/refs/tags/v%s.tar.gz" % BOOST_UT_VERSION,
+    url = "https://github.com/boost-ext/ut/archive/%s.tar.gz" % BOOST_UT_VERSION,
 )
 
 GOOGLE_BENCHMARK_VERSION = "1.8.0"

--- a/huffman/test/BUILD.bazel
+++ b/huffman/test/BUILD.bazel
@@ -5,8 +5,8 @@ cc_test(
     timeout = "short",
     srcs = ["bit_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//huffman",
-        "@boost_ut",
     ],
 )
 
@@ -15,8 +15,8 @@ cc_test(
     timeout = "short",
     srcs = ["code_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//huffman",
-        "@boost_ut",
     ],
 )
 
@@ -25,8 +25,8 @@ cc_test(
     timeout = "short",
     srcs = ["table_canonicalize_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//huffman",
-        "@boost_ut",
     ],
 )
 
@@ -35,8 +35,8 @@ cc_test(
     timeout = "short",
     srcs = ["table_find_code_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//huffman",
-        "@boost_ut",
     ],
 )
 
@@ -45,8 +45,8 @@ cc_test(
     timeout = "short",
     srcs = ["table_from_frequencies_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//huffman",
-        "@boost_ut",
     ],
 )
 
@@ -55,8 +55,8 @@ cc_test(
     timeout = "short",
     srcs = ["table_from_data_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//huffman",
-        "@boost_ut",
     ],
 )
 
@@ -65,8 +65,8 @@ cc_test(
     timeout = "short",
     srcs = ["table_from_contents_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//huffman",
-        "@boost_ut",
     ],
 )
 
@@ -75,8 +75,8 @@ cc_test(
     timeout = "short",
     srcs = ["table_from_symbol_bitsize_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//huffman",
-        "@boost_ut",
     ],
 )
 
@@ -85,8 +85,8 @@ cc_test(
     timeout = "short",
     srcs = ["bit_span_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//huffman",
-        "@boost_ut",
     ],
 )
 
@@ -95,8 +95,8 @@ cc_test(
     timeout = "short",
     srcs = ["decode_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//huffman",
-        "@boost_ut",
     ],
 )
 

--- a/huffman/test/bit_span_test.cpp
+++ b/huffman/test/bit_span_test.cpp
@@ -7,6 +7,7 @@
 #include <climits>
 #include <cstdint>
 #include <numeric>
+#include <ranges>
 #include <vector>
 
 auto main() -> int
@@ -91,9 +92,6 @@ auto main() -> int
     }));
   } | std::vector<std::uint8_t>{8, 9, 10};  // NOLINT(readability-magic-numbers)
 
-  std::vector<size_t> n_to_consume(1Z + 2Z * CHAR_BIT);
-  std::iota(n_to_consume.begin(), n_to_consume.end(), 0);
-
   test("consume") = [](size_t n) {
     static constexpr auto data = huffman::byte_array(0b10101010, 0b01010101);
 
@@ -114,7 +112,7 @@ auto main() -> int
     } else {
       expect(aborts([&] { bits.consume(n); }));
     }
-  } | n_to_consume;
+  } | std::views::iota(0UZ, 2UZ * (CHAR_BIT + 1UZ));
 
   test("consume_to_byte_boundary") = [] {
     static constexpr auto data = huffman::byte_array(0b10101010, 0b01010101);
@@ -135,21 +133,21 @@ auto main() -> int
   };
 
   test("pop") = [] {
+    using ::boost::ut::eq;
+
     // NOLINTBEGIN(readability-magic-numbers)
     static constexpr auto data =
         huffman::byte_array(0b10101010, 0b01010101, 0b11111111);
     huffman::bit_span span{data};
     const std::uint16_t got_16{span.pop_16()};
     constexpr std::uint16_t expected_16{0b0101010110101010};
-    expect(got_16 == expected_16)
-        << "got: " << got_16 << " expected: " << expected_16;
+    expect(eq(got_16, expected_16));
 
     expect(aborts([&] { span.pop_16(); }));
 
     const std::uint8_t got_8{span.pop_8()};
     constexpr std::uint8_t expected_8{0b11111111};
-    expect(got_8 == expected_8)
-        << "got: " << got_8 << " expected: " << expected_8;
+    expect(eq(got_8, expected_8));
 
     expect(aborts([&] { span.pop_8(); }));
     // NOLINTEND(readability-magic-numbers)

--- a/src/test/BUILD.bazel
+++ b/src/test/BUILD.bazel
@@ -5,6 +5,7 @@ cc_test(
     timeout = "short",
     srcs = ["decompress_test.cpp"],
     deps = [
+        "//:boost_ut",
         "//src:decompress",
     ],
 )

--- a/test_ut/BUILD.bazel
+++ b/test_ut/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "test_ut_example",
+    srcs = ["test_ut_example.cpp"],
+    deps = ["//:boost_ut"],
+)

--- a/test_ut/test_ut_example.cpp
+++ b/test_ut/test_ut_example.cpp
@@ -1,0 +1,32 @@
+#include <boost/ut.hpp>
+
+#include <array>
+#include <ranges>
+
+auto main() -> int
+{
+  using ::boost::ut::expect;
+  using ::boost::ut::range_eq;
+  using ::boost::ut::test;
+
+  test("test range eq, lhs smaller") = [] {
+    constexpr auto data1 = std::array{1, 2, 3};
+    constexpr auto data2 = std::views::iota(1, 5);
+
+    expect(range_eq(data1, data2));
+  };
+
+  test("test range eq, lhs bigger") = [] {
+    constexpr auto data1 = std::array{1, 2, 3};
+    constexpr auto data2 = std::views::iota(1, 3);
+
+    expect(range_eq(data1, data2));
+  };
+
+  test("test range eq, value mismatch") = [] {
+    constexpr auto data1 = std::array{1, 2, 4};
+    constexpr auto data2 = std::views::iota(1, 4);
+
+    expect(range_eq(data1, data2));
+  };
+}

--- a/ut.hpp
+++ b/ut.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <include/boost/ut.hpp>
+
+#include <algorithm>
+#include <optional>
+#include <ranges>
+#include <type_traits>
+
+namespace boost::ut {
+namespace detail {
+
+template <class TLhs, class TRhs>
+struct range_eq_ : op
+{
+  constexpr range_eq_(const TLhs& lhs = {}, const TRhs& rhs = {})
+      : lhs_{lhs},
+        rhs_{rhs},
+        error_{[&] -> std::remove_const_t<decltype(error_)> {
+          if constexpr (
+              type_traits::is_range_v<TLhs> and type_traits::is_range_v<TRhs>) {
+            using std::ranges::cend;
+
+            auto count = unsigned{};
+
+            const auto result = std::ranges::mismatch(
+                lhs_, rhs_, [&count](const auto& x, const auto& y) {
+                  using std::operator==;
+                  ++count;
+                  return x == y;
+                });
+
+            if (result.in1 == cend(lhs_) and result.in2 == cend(rhs_)) {
+              return {};
+            }
+
+            if (result.in1 != cend(lhs_) and result.in2 != cend(rhs_)) {
+              return {{count - 1U, result.in1, result.in2}};
+            }
+
+            return {{count, result.in1, result.in2}};
+          }
+        }()}
+  {}
+
+  [[nodiscard]]
+  constexpr
+  operator bool() const
+  {
+    return not error_;
+  }
+  [[nodiscard]]
+  constexpr auto& lhs() const
+  {
+    return lhs_;
+  }
+  [[nodiscard]]
+  constexpr auto& rhs() const
+  {
+    return rhs_;
+  }
+  [[nodiscard]]
+  constexpr auto error() const
+  {
+    return *error_;
+  }
+
+  const TLhs lhs_{};
+  const TRhs rhs_{};
+  const std::optional<std::tuple<
+      unsigned,
+      std::ranges::iterator_t<const TLhs>,
+      std::ranges::iterator_t<const TRhs>>>
+      error_{};
+
+  friend auto& operator<<(printer& p, const range_eq_& op)
+  {
+    static constexpr auto colors_ = colors{};
+    static constexpr auto color = [](bool cond) {
+      return cond ? colors_.pass : colors_.fail;
+    };
+
+    p << color(op) << "ranges_eq(" << reflection::decay_type_name<TLhs>()
+      << ", " << reflection::decay_type_name<TRhs>() << ")";
+
+    if (not op) {
+      const auto [index, in1, in2] = op.error();
+
+      p << "\n at element " << index << ": ";
+
+      if (in1 != op.lhs().end() and in2 != op.rhs().end()) {
+        p << "[ " << *in1 << " == " << *in2 << " ]";
+      } else if (in1 == op.lhs().end()) {
+        p << "lhs has fewer elements than rhs";
+      } else {
+        p << "lhs has more elements than rhs";
+      }
+    }
+
+    return (p << colors_.none);
+  }
+};
+
+}  // namespace detail
+
+template <class TLhs, class TRhs>
+[[nodiscard]]
+constexpr auto range_eq(const TLhs& lhs, const TRhs& rhs)
+{
+  return detail::range_eq_{lhs, rhs};
+}
+
+}  // namespace boost::ut


### PR DESCRIPTION
Define the function `boost::ut::range_eq` that compares elements in two
ranges. If the elements are not equal, this function displays the first
mismatch in the two ranges or if one range is larger than another.

This commit also updates `boost-ut` to allow use of ranges in
parameterized tests.

resolves #106

Change-Id: I24b4f37927799c7eb3b68d3ac2ce159f60e3d94f