### PR TITLE
fix clangd instructions

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -6,4 +6,3 @@ CompileFlags:
   # Specifying non-existent include paths on other platforms doesn't cause issues
   # (e.g. mentioning linux-gnu works on MacOS).
   Add: [-nostdinc++, -isystem, external/llvm_toolchain_files/include/x86_64-unknown-linux-gnu/c++/v1, -isystem, external/llvm_toolchain_files/include/c++/v1]
-

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install the recommended extensions. See .vscode/extensions.json.
 Create a compilation database:
 
 ```sh
-bazel build //... && bazel run @hedron_compile_commands//:refresh_all
+bazel run @hedron_compile_commands//:refresh_all && bazel build //...
 ```
 
 Then configure [clangd](https://clangd.llvm.org/).


### PR DESCRIPTION
fix clangd instructions

work around https://github.com/hedronvision/bazel-compile-commands-extractor/issues/140

Change-Id: I86a23ad7ffc699773a9219a3c766e22df0946479