### PR TITLE
test data for fixed and dynamic huffman trees

### DIFF
--- a/src/test/BUILD.bazel
+++ b/src/test/BUILD.bazel
@@ -1,12 +1,30 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//tools:compressed_file.bzl", "compressed_file")
 
 cc_test(
     name = "decompress_test",
     timeout = "short",
     srcs = ["decompress_test.cpp"],
+    data = [
+        ":starfleet.html.dynamic",
+        ":starfleet.html.fixed",
+    ],
     deps = [
         "//:boost_ut",
         "//src:decompress",
+        "@bazel_tools//tools/cpp/runfiles",
         "@boost_ut",
     ],
+)
+
+compressed_file(
+    name = "starfleet.html.dynamic",
+    src = "starfleet.html",
+    strategy = "dynamic",
+)
+
+compressed_file(
+    name = "starfleet.html.fixed",
+    src = "starfleet.html",
+    strategy = "fixed",
 )

--- a/src/test/decompress_test.cpp
+++ b/src/test/decompress_test.cpp
@@ -1,8 +1,12 @@
 #include "huffman/src/utility.hpp"
 #include "src/decompress.hpp"
+#include "tools/cpp/runfiles/runfiles.h"
 
 #include <boost/ut.hpp>
 
+#include <fstream>
+#include <iterator>
+#include <memory>
 #include <vector>
 
 template <class... Ts>
@@ -11,7 +15,36 @@ constexpr auto byte_vector(Ts... values)
   return std::vector<std::byte>{std::byte(values)...};
 }
 
-auto main() -> int
+auto read_runfile(const char* argv0, const std::string& path)
+    -> std::vector<std::byte>
+{
+  using ::bazel::tools::cpp::runfiles::Runfiles;
+  std::string error;
+  std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv0, &error));
+  ::boost::ut::expect(::boost::ut::fatal(runfiles != nullptr)) << error;
+
+  const std::string abs_path{runfiles->Rlocation(path)};
+
+  std::ifstream file{abs_path, std::ios::binary};
+  ::boost::ut::expect(::boost::ut::fatal(file.is_open()))
+      << "failed to open " << path;
+  std::vector<char> chars(
+      (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+
+  const std::vector<char> char_vector(
+      (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+
+  // The standard library really doesn't want me to read std::byte from a file,
+  // so reinterpret chars as bytes.
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  return {
+      reinterpret_cast<std::byte*>(chars.data()),
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      reinterpret_cast<std::byte*>(chars.data() + chars.size())};
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+}
+
+auto main(int, char* argv[]) -> int
 {
   using ::boost::ut::eq;
   using ::boost::ut::expect;
@@ -70,15 +103,25 @@ auto main() -> int
     expect(*actual == expected);
   };
 
-  test("fixed huffman") = [] {
-    constexpr auto compressed = huffman::byte_array(0b101);
-    const auto actual = decompress(compressed);
-    expect(not actual.has_value());
+  test("fixed huffman") = [argv] {
+    const std::vector<std::byte> input_bytes =
+        read_runfile(*argv, "starflate/src/test/starfleet.html.fixed");
+    huffman::bit_span input_bits(input_bytes);
+
+    const auto header = detail::read_header(input_bits);
+    expect(header.has_value())
+        << "got error: " << static_cast<int>(header.error());
+    expect(header->type == detail::BlockType::FixedHuffman);
   };
 
-  test("dynamic huffman") = [] {
-    constexpr auto compressed = huffman::byte_array(0b011);
-    const auto actual = decompress(compressed);
-    expect(not actual.has_value());
+  test("dynamic huffman") = [argv] {
+    const std::vector<std::byte> input_bytes =
+        read_runfile(*argv, "starflate/src/test/starfleet.html.dynamic");
+    huffman::bit_span input_bits(input_bytes);
+
+    const auto header = detail::read_header(input_bits);
+    expect(header.has_value())
+        << "got error: " << static_cast<int>(header.error());
+    expect(header->type == detail::BlockType::DynamicHuffman);
   };
 };

--- a/src/test/starfleet.html
+++ b/src/test/starfleet.html
@@ -1,0 +1,1166 @@
+<!DOCTYPE html>
+<html class="client-nojs vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-enabled vector-feature-page-tools-pinned-enabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-enabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-zebra-design-disabled vector-feature-custom-font-size-clientpref-0 vector-feature-client-preferences-disabled vector-feature-typography-survey-disabled vector-sticky-header-enabled vector-toc-available" lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8">
+<title>Starfleet - Wikipedia</title>
+<script>document.documentElement.className="client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-enabled vector-feature-page-tools-pinned-enabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-enabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-zebra-design-disabled vector-feature-custom-font-size-clientpref-0 vector-feature-client-preferences-disabled vector-feature-typography-survey-disabled vector-sticky-header-enabled vector-toc-available";RLCONF={"wgBreakFrames":false,"wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgRequestId":"ba88542b-0730-430b-9b49-2adb8bc30b4b","wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,
+"wgPageName":"Starfleet","wgTitle":"Starfleet","wgCurRevisionId":1182208104,"wgRevisionId":1182208104,"wgArticleId":29340,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":"Garymm","wgUserGroups":["*","user","autoconfirmed"],"wgCategories":["Articles with short description","Short description matches Wikidata","Short description is different from Wikidata","Fictional elements introduced in 1966","Star Trek organizations","Space navies"],"wgPageViewLanguage":"en","wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgRelevantPageName":"Starfleet","wgRelevantArticleId":29340,"wgUserId":7391608,"wgUserIsTemp":false,"wgUserEditCount":75,"wgUserRegistration":1214715893000,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgNoticeProject":"wikipedia","wgNoticeUserData":{"registration":"20080629050453"},"wgFlaggedRevsParams":{"tags":{"status":{"levels":1}}},"wgGlobalGroups":[],"wgMediaViewerOnClick"
+:true,"wgMediaViewerEnabledByDefault":true,"wgPopupsFlags":10,"wgVisualEditor":{"pageLanguageCode":"en","pageLanguageDir":"ltr","pageVariantFallbacks":"en"},"wgMFDisplayWikibaseDescriptions":{"search":true,"watchlist":true,"tagline":false,"nearby":true},"wgWMESchemaEditAttemptStepOversample":false,"wgWMEPageLength":20000,"wgULSAcceptLanguageList":["en-us","en","es"],"wgULSBabelLanguages":[],"wgULSCurrentAutonym":"English","wgEditSubmitButtonLabelPublish":true,"wgULSPosition":"interlanguage","wgULSisCompactLinksEnabled":true,"wgULSisLanguageSelectorEmpty":false,"wgWikibaseItemId":"Q718644","wgCheckUserClientHintsHeadersJsApi":["architecture","bitness","brands","fullVersionList","mobile","model","platform","platformVersion"],"GEHomepageSuggestedEditsEnableTopics":true,"wgGETopicsMatchModeEnabled":false,"wgGEStructuredTaskRejectionReasonTextInputEnabled":false,"wgGELevelingUpEnabledForUser":false,"wgEchoSeenTime":{"alert":"1970-01-01T00:00:01Z","notice":"1970-01-01T00:00:01Z"}};RLSTATE={
+"skins.vector.user.styles":"ready","ext.gadget.SubtleUpdatemarker":"ready","ext.gadget.dark-mode-toggle-pagestyles":"ready","ext.gadget.dark-mode":"ready","ext.globalCssJs.user.styles":"ready","site.styles":"ready","user.styles":"ready","skins.vector.user":"ready","ext.globalCssJs.user":"ready","user":"loading","user.options":"loading","ext.cite.styles":"ready","codex-search-styles":"ready","skins.vector.styles":"ready","skins.vector.icons":"ready","jquery.makeCollapsible.styles":"ready","ext.visualEditor.desktopArticleTarget.noscript":"ready","ext.echo.styles.badge":"ready","oojs-ui.styles.icons-alerts":"ready","ext.uls.interlanguage":"ready","wikibase.client.init":"ready","ext.wikimediaBadges":"ready"};RLPAGEMODULES=["ext.cite.ux-enhancements","mediawiki.page.media","site","mediawiki.page.ready","jquery.makeCollapsible","mediawiki.toc","skins.vector.js","mediawiki.page.watch.ajax","ext.centralNotice.geoIP","ext.centralNotice.startUp","ext.gadget.ReferenceTooltips",
+"ext.gadget.geonotice","ext.gadget.switcher","ext.gadget.dark-mode-toggle","ext.urlShortener.toolbar","ext.centralauth.centralautologin.clearcookie","mmv.head","mmv.bootstrap.autostart","ext.visualEditor.desktopArticleTarget.init","ext.visualEditor.targetLoader","ext.echo.init","ext.eventLogging","ext.wikimediaEvents","ext.navigationTiming","ext.uls.compactlinks","ext.uls.interface","ext.cx.eventlogging.campaigns","ext.cx.uls.quick.actions","wikibase.client.vector-2022","ext.checkUser.clientHints","ext.quicksurveys.init","ext.growthExperiments.SuggestedEditSession"];</script>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.loader.load("/w/load.php?lang=en\u0026modules=user\u0026skin=vector-2022\u0026user=Garymm\u0026version=n24il");mw.loader.impl(function(){return["user.options@12s5i",function($,jQuery,require,module){mw.user.tokens.set({"patrolToken":"b136c2905f7f688e41e8a7dccc3505e5655ae9de+\\","watchToken":"f16862140bdc17465095075ca463aab4655ae9de+\\","csrfToken":"2dc9301e7efb4e1952482d97f88d2b5a655ae9de+\\"});mw.user.options.set({"VectorSidebarVisible":0,"VectorSkinVersion":"2","centralnotice-display-campaign-type-advocacy":0,"centralnotice-display-campaign-type-article-writing":0,"centralnotice-display-campaign-type-event":0,"centralnotice-display-campaign-type-fundraising":0,"centralnotice-display-campaign-type-governance":0,"centralnotice-display-campaign-type-photography":0,"citoid-mode":"\"auto\"","date":"ISO 8601","echo-subscriptions-email-edit-user-talk":1,"echo-subscriptions-push-ge-newcomer":"","fileexporter":0,"gadget-HideFundraisingNotice":"1","gadget-dark-mode":"1","gadget-dark-mode-toggle":"1","gender":"male","ipinfo-beta-feature-enable":0,"mf_amc_optin":"1","monobook-responsive":0,"thumbsize":"2","timecorrection":"ZoneInfo|-480|America/Los_Angeles","twocolconflict":0,
+"usecodemirror-colorblind":0,"uselivepreview":"1","userjs-revslider-hide-help-dialogue":"1","visualeditor-diffmode-visual":"\"visual\"","visualeditor-editor":"visualeditor","visualeditor-findAndReplace-diacritic":"false","visualeditor-findAndReplace-findText":"\"olfaction\"","visualeditor-findAndReplace-matchCase":"false","visualeditor-findAndReplace-regex":"false","visualeditor-findAndReplace-replaceText":"\"\"","visualeditor-findAndReplace-word":"false","visualeditor-hidebetawelcome":"1","visualeditor-hidetabdialog":"1","visualeditor-hideusered":"1","visualeditor-hidevisualswitchpopup":"1","visualeditor-tabs":"prefer-ve","watchcreations":0,"watchlisttoken":"03aa64aacf8373a053fdd3be9878aa0838ed900d","wikieditor-realtime-preview":0});
+}];});});</script>
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=codex-search-styles%7Cext.cite.styles%7Cext.echo.styles.badge%7Cext.uls.interlanguage%7Cext.visualEditor.desktopArticleTarget.noscript%7Cext.wikimediaBadges%7Cjquery.makeCollapsible.styles%7Coojs-ui.styles.icons-alerts%7Cskins.vector.icons%2Cstyles%7Cwikibase.client.init&amp;only=styles&amp;skin=vector-2022">
+<script async="" src="/w/load.php?lang=en&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=vector-2022"></script>
+<meta name="ResourceLoaderDynamicStyles" content="">
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=ext.gadget.SubtleUpdatemarker%2Cdark-mode%2Cdark-mode-toggle-pagestyles&amp;only=styles&amp;skin=vector-2022">
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=vector-2022">
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=user.styles&amp;only=styles&amp;skin=vector-2022&amp;user=Garymm&amp;version=4pug3">
+<meta name="generator" content="MediaWiki 1.42.0-wmf.5">
+<meta name="referrer" content="origin">
+<meta name="referrer" content="origin-when-cross-origin">
+<meta name="robots" content="max-image-preview:standard">
+<meta name="format-detection" content="telephone=no">
+<meta name="viewport" content="width=1000">
+<meta property="og:title" content="Starfleet - Wikipedia">
+<meta property="og:type" content="website">
+<link rel="preconnect" href="//upload.wikimedia.org">
+<link rel="alternate" media="only screen and (max-width: 720px)" href="//en.m.wikipedia.org/wiki/Starfleet">
+<link rel="alternate" type="application/x-wiki" title="Edit this page" href="/w/index.php?title=Starfleet&amp;action=edit">
+<link rel="apple-touch-icon" href="/static/apple-touch/wikipedia.png">
+<link rel="icon" href="/static/favicon/wikipedia.ico">
+<link rel="search" type="application/opensearchdescription+xml" href="/w/opensearch_desc.php" title="Wikipedia (en)">
+<link rel="EditURI" type="application/rsd+xml" href="//en.wikipedia.org/w/api.php?action=rsd">
+<link rel="canonical" href="https://en.wikipedia.org/wiki/Starfleet">
+<link rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.en">
+<link rel="alternate" type="application/atom+xml" title="Wikipedia Atom feed" href="/w/index.php?title=Special:RecentChanges&amp;feed=atom">
+<link rel="dns-prefetch" href="//meta.wikimedia.org" />
+</head>
+<body class="skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-Starfleet rootpage-Starfleet skin-vector-2022 action-view"><a class="mw-jump-link" href="#bodyContent">Jump to content</a>
+<div class="vector-header-container">
+	<header class="vector-header mw-header">
+		<div class="vector-header-start">
+			<nav class="vector-main-menu-landmark" aria-label="Site" role="navigation">
+				
+<div id="vector-main-menu-dropdown" class="vector-dropdown vector-main-menu-dropdown vector-button-flush-left vector-button-flush-right"  >
+	<input type="checkbox" id="vector-main-menu-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-main-menu-dropdown" class="vector-dropdown-checkbox "  aria-label="Main menu"  >
+	<label id="vector-main-menu-dropdown-label" for="vector-main-menu-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-menu mw-ui-icon-wikimedia-menu"></span>
+
+<span class="vector-dropdown-label-text">Main menu</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+				<div id="vector-main-menu-unpinned-container" class="vector-unpinned-container">
+		
+				</div>
+
+	</div>
+</div>
+
+		</nav>
+			
+<a href="/wiki/Main_Page" class="mw-logo">
+	<img class="mw-logo-icon" src="/static/images/icons/wikipedia.png" alt="" aria-hidden="true" height="50" width="50">
+	<span class="mw-logo-container">
+		<img class="mw-logo-wordmark" alt="Wikipedia" src="/static/images/mobile/copyright/wikipedia-wordmark-en.svg" style="width: 7.5em; height: 1.125em;">
+		<img class="mw-logo-tagline" alt="The Free Encyclopedia" src="/static/images/mobile/copyright/wikipedia-tagline-en.svg" width="117" height="13" style="width: 7.3125em; height: 0.8125em;">
+	</span>
+</a>
+
+		</div>
+		<div class="vector-header-end">
+			
+<div id="p-search" role="search" class="vector-search-box-vue  vector-search-box-collapses vector-search-box-show-thumbnail vector-search-box-auto-expand-width vector-search-box">
+	<a href="/wiki/Special:Search" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only search-toggle" id="" title="Search Wikipedia [f]" accesskey="f"><span class="vector-icon mw-ui-icon-search mw-ui-icon-wikimedia-search"></span>
+
+<span>Search</span>
+	</a>
+	<div class="vector-typeahead-search-container">
+		<div class="cdx-typeahead-search cdx-typeahead-search--show-thumbnail cdx-typeahead-search--auto-expand-width">
+			<form action="/w/index.php" id="searchform" class="cdx-search-input cdx-search-input--has-end-button">
+				<div id="simpleSearch" class="cdx-search-input__input-wrapper"  data-search-loc="header-moved">
+					<div class="cdx-text-input cdx-text-input--has-start-icon">
+						<input
+							class="cdx-text-input__input"
+							 type="search" name="search" placeholder="Search Wikipedia" aria-label="Search Wikipedia" autocapitalize="sentences" title="Search Wikipedia [f]" accesskey="f" id="searchInput"
+							>
+						<span class="cdx-text-input__icon cdx-text-input__start-icon"></span>
+					</div>
+					<input type="hidden" name="title" value="Special:Search">
+				</div>
+				<button class="cdx-button cdx-search-input__end-button">Search</button>
+			</form>
+		</div>
+	</div>
+</div>
+
+			<nav class="vector-user-links vector-user-links-wide" aria-label="Personal tools" role="navigation" >
+	<div class="vector-user-links-main">
+	
+<div id="p-vector-user-menu-preferences" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-userpage" class="vector-menu mw-portlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			<li id="pt-userpage-2" class="mw-list-item user-links-collapsible-item"><a data-mw="interface" href="/wiki/User:Garymm" class="new" title="Your user page (page does not exist) [.]" accesskey="."><span>Garymm</span></a>
+</li>
+
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-notifications" class="vector-menu mw-portlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			<li id="pt-notifications-alert" class="mw-list-item"><a data-mw="interface" href="/wiki/Special:Notifications" class="mw-echo-notification-badge-nojs cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only" data-event-name="ui.notifications" data-counter-num="0" data-counter-text="0" title="Your alerts"><span class="vector-icon mw-ui-icon-bell mw-ui-icon-wikimedia-bell"></span>
+
+<span>Alerts (0)</span></a>
+</li>
+<li id="pt-notifications-notice" class="mw-list-item"><a data-mw="interface" href="/wiki/Special:Notifications" class="mw-echo-notification-badge-nojs cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only" data-counter-num="0" data-counter-text="0" title="Your notices"><span class="vector-icon mw-ui-icon-tray mw-ui-icon-wikimedia-tray"></span>
+
+<span>Notices (0)</span></a>
+</li>
+
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-overflow" class="vector-menu mw-portlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			<li id="pt-watchlist-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw="interface" href="/wiki/Special:Watchlist" title="The list of pages you are monitoring for changes [L]" accesskey="L" class=" cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only"><span class="vector-icon mw-ui-icon-watchlist mw-ui-icon-wikimedia-watchlist"></span>
+
+<span>Watchlist</span></a>
+</li>
+
+			
+		</ul>
+		
+	</div>
+</div>
+
+	</div>
+	
+<div id="vector-user-links-dropdown" class="vector-dropdown vector-user-menu vector-button-flush-right vector-user-menu-logged-in"  >
+	<input type="checkbox" id="vector-user-links-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-user-links-dropdown" class="vector-dropdown-checkbox "  aria-label="Personal tools"  >
+	<label id="vector-user-links-dropdown-label" for="vector-user-links-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-userAvatar mw-ui-icon-wikimedia-userAvatar"></span>
+
+<span class="vector-dropdown-label-text">Personal tools</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+		
+<div id="p-personal" class="vector-menu mw-portlet mw-portlet-personal"  title="User menu" >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="pt-userpage" class="user-links-collapsible-item mw-list-item"><a class="new" href="/wiki/User:Garymm" title="Your user page (page does not exist) [.]" accesskey="."><span class="vector-icon mw-ui-icon-userAvatar mw-ui-icon-wikimedia-userAvatar"></span> <span>Garymm</span></a></li><li id="pt-mytalk" class="mw-list-item"><a href="/wiki/User_talk:Garymm" title="Your talk page [n]" accesskey="n"><span class="vector-icon mw-ui-icon-userTalk mw-ui-icon-wikimedia-userTalk"></span> <span>Talk</span></a></li><li id="pt-sandbox" class="new mw-list-item"><a href="/w/index.php?title=User:Garymm/sandbox&amp;action=edit&amp;redlink=1&amp;preload=Template%3AUser+sandbox%2Fpreload" title="Your sandbox (page does not exist)"><span class="vector-icon mw-ui-icon-sandbox mw-ui-icon-wikimedia-sandbox"></span> <span>Sandbox</span></a></li><li id="pt-preferences" class="mw-list-item"><a href="/wiki/Special:Preferences" title="Your preferences"><span class="vector-icon mw-ui-icon-settings mw-ui-icon-wikimedia-settings"></span> <span>Preferences</span></a></li><li id="pt-betafeatures" class="mw-list-item"><a href="/wiki/Special:Preferences#mw-prefsection-betafeatures" title="Beta features"><span class="vector-icon mw-ui-icon-labFlask mw-ui-icon-wikimedia-labFlask"></span> <span>Beta</span></a></li><li id="pt-watchlist" class="user-links-collapsible-item mw-list-item"><a href="/wiki/Special:Watchlist" title="The list of pages you are monitoring for changes [L]" accesskey="L"><span class="vector-icon mw-ui-icon-watchlist mw-ui-icon-wikimedia-watchlist"></span> <span>Watchlist</span></a></li><li id="pt-mycontris" class="mw-list-item"><a href="/wiki/Special:Contributions/Garymm" title="A list of your contributions [y]" accesskey="y"><span class="vector-icon mw-ui-icon-userContributions mw-ui-icon-wikimedia-userContributions"></span> <span>Contributions</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-user-menu-logout" class="vector-menu mw-portlet mw-portlet-user-menu-logout"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="pt-logout" class="mw-list-item"><a data-mw="interface" href="/w/index.php?title=Special:UserLogout&amp;returnto=Starfleet" title="Log out"><span class="vector-icon mw-ui-icon-logOut mw-ui-icon-wikimedia-logOut"></span> <span>Log out</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+	</div>
+</div>
+
+</nav>
+
+		</div>
+	</header>
+</div>
+<div class="mw-page-container">
+	<div class="mw-page-container-inner">
+		<div class="vector-sitenotice-container">
+			<div id="siteNotice"><!-- CentralNotice --></div>
+		</div>
+		
+			<div class="vector-main-menu-container">
+		<div id="mw-navigation">
+			<nav id="mw-panel" class="vector-main-menu-landmark" aria-label="Site" role="navigation">
+				<div id="vector-main-menu-pinned-container" class="vector-pinned-container">
+				
+<div id="vector-main-menu" class="vector-main-menu vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-main-menu-pinnable-header vector-pinnable-header-pinned"
+	data-feature-name="main-menu-pinned"
+	data-pinnable-element-id="vector-main-menu"
+	data-pinned-container-id="vector-main-menu-pinned-container"
+	data-unpinned-container-id="vector-main-menu-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Main menu</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-main-menu.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-main-menu.unpin">hide</button>
+</div>
+
+	
+<div id="p-navigation" class="vector-menu mw-portlet mw-portlet-navigation"  >
+	<div class="vector-menu-heading">
+		Navigation
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-mainpage-description" class="mw-list-item"><a href="/wiki/Main_Page" title="Visit the main page [z]" accesskey="z"><span>Main page</span></a></li><li id="n-contents" class="mw-list-item"><a href="/wiki/Wikipedia:Contents" title="Guides to browsing Wikipedia"><span>Contents</span></a></li><li id="n-currentevents" class="mw-list-item"><a href="/wiki/Portal:Current_events" title="Articles related to current events"><span>Current events</span></a></li><li id="n-randompage" class="mw-list-item"><a href="/wiki/Special:Random" title="Visit a randomly selected article [x]" accesskey="x"><span>Random article</span></a></li><li id="n-aboutsite" class="mw-list-item"><a href="/wiki/Wikipedia:About" title="Learn about Wikipedia and how it works"><span>About Wikipedia</span></a></li><li id="n-contactpage" class="mw-list-item"><a href="//en.wikipedia.org/wiki/Wikipedia:Contact_us" title="How to contact Wikipedia"><span>Contact us</span></a></li><li id="n-sitesupport" class="mw-list-item"><a href="https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&amp;utm_medium=sidebar&amp;utm_campaign=C13_en.wikipedia.org&amp;uselang=en" title="Support us by donating to the Wikimedia Foundation"><span>Donate</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div class="vector-main-menu-action vector-main-menu-action-opt-out">
+	<div class="vector-main-menu-action-item">
+		
+		<div class="vector-main-menu-action-content vector-menu-content">
+			<a href="/w/index.php?title=Special:Preferences&amp;useskin=vector&amp;wprov=vctw1#mw-prefsection-rendering-skin" title="Change your settings to go back to the old look of the skin (legacy Vector)"><span>Switch to old look</span></a>
+		</div>
+	</div>
+</div>
+
+	
+<div id="p-interaction" class="vector-menu mw-portlet mw-portlet-interaction"  >
+	<div class="vector-menu-heading">
+		Contribute
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-help" class="mw-list-item"><a href="/wiki/Help:Contents" title="Guidance on how to use and edit Wikipedia"><span>Help</span></a></li><li id="n-introduction" class="mw-list-item"><a href="/wiki/Help:Introduction" title="Learn how to edit Wikipedia"><span>Learn to edit</span></a></li><li id="n-portal" class="mw-list-item"><a href="/wiki/Wikipedia:Community_portal" title="The hub for editors"><span>Community portal</span></a></li><li id="n-recentchanges" class="mw-list-item"><a href="/wiki/Special:RecentChanges" title="A list of recent changes to Wikipedia [r]" accesskey="r"><span>Recent changes</span></a></li><li id="n-upload" class="mw-list-item"><a href="/wiki/Wikipedia:File_upload_wizard" title="Add images or other media for use on Wikipedia"><span>Upload file</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div class="vector-main-menu-action vector-main-menu-action-lang-alert">
+	<div class="vector-main-menu-action-item">
+		<div class="vector-main-menu-action-heading vector-menu-heading">Languages</div>
+		<div class="vector-main-menu-action-content vector-menu-content">
+			<div class="mw-message-box cdx-message cdx-message--block mw-message-box-notice cdx-message--notice vector-language-sidebar-alert"><span class="cdx-message__icon"></span><div class="cdx-message__content">Language links are at the top of the page across from the title.</div></div>
+		</div>
+	</div>
+</div>
+
+</div>
+
+				</div>
+		</nav>
+		</div>
+	</div>
+	<nav id="mw-panel-toc" role="navigation" aria-label="Contents" data-event-name="ui.sidebar-toc" class="mw-table-of-contents-container vector-toc-landmark vector-sticky-pinned-container">
+				<div id="vector-toc-pinned-container" class="vector-pinned-container">
+				<div id="vector-toc" class="vector-toc vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-toc-pinnable-header vector-pinnable-header-pinned"
+	data-feature-name="toc-pinned"
+	data-pinnable-element-id="vector-toc"
+	
+	
+>
+	<h2 class="vector-pinnable-header-label">Contents</h2>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-toc.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-toc.unpin">hide</button>
+</div>
+
+
+	<ul class="vector-toc-contents" id="mw-panel-toc-list">
+		<li id="toc-mw-content-text"
+			class="vector-toc-list-item vector-toc-level-1">
+			<a href="#" class="vector-toc-link">
+				<div class="vector-toc-text">(Top)</div>
+			</a>
+		</li>
+		<li id="toc-History"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#History">
+			<div class="vector-toc-text">
+			<span class="vector-toc-numb">1</span>History</div>
+		</a>
+		
+		<ul id="toc-History-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-Mission"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Mission">
+			<div class="vector-toc-text">
+			<span class="vector-toc-numb">2</span>Mission</div>
+		</a>
+		
+		<ul id="toc-Mission-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-Components"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Components">
+			<div class="vector-toc-text">
+			<span class="vector-toc-numb">3</span>Components</div>
+		</a>
+		
+			<button aria-controls="toc-Components-sublist" class="cdx-button cdx-button--weight-quiet cdx-button--icon-only vector-toc-toggle">
+				<span class="vector-icon vector-icon--x-small mw-ui-icon-wikimedia-expand"></span>
+				<span>Toggle Components subsection</span>
+			</button>
+		
+		<ul id="toc-Components-sublist" class="vector-toc-list">
+			<li id="toc-Starfleet_Academy"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Starfleet_Academy">
+				<div class="vector-toc-text">
+				<span class="vector-toc-numb">3.1</span>Starfleet Academy</div>
+			</a>
+			
+			<ul id="toc-Starfleet_Academy-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Starfleet_Command"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Starfleet_Command">
+				<div class="vector-toc-text">
+				<span class="vector-toc-numb">3.2</span>Starfleet Command</div>
+			</a>
+			
+			<ul id="toc-Starfleet_Command-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Starfleet_Shipyards"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Starfleet_Shipyards">
+				<div class="vector-toc-text">
+				<span class="vector-toc-numb">3.3</span>Starfleet Shipyards</div>
+			</a>
+			
+			<ul id="toc-Starfleet_Shipyards-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Starfleet_Engineering_Corps"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Starfleet_Engineering_Corps">
+				<div class="vector-toc-text">
+				<span class="vector-toc-numb">3.4</span>Starfleet Engineering Corps</div>
+			</a>
+			
+			<ul id="toc-Starfleet_Engineering_Corps-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Starfleet_Intelligence"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Starfleet_Intelligence">
+				<div class="vector-toc-text">
+				<span class="vector-toc-numb">3.5</span>Starfleet Intelligence</div>
+			</a>
+			
+			<ul id="toc-Starfleet_Intelligence-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Starfleet_Judge_Advocate_General"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Starfleet_Judge_Advocate_General">
+				<div class="vector-toc-text">
+				<span class="vector-toc-numb">3.6</span>Starfleet Judge Advocate General</div>
+			</a>
+			
+			<ul id="toc-Starfleet_Judge_Advocate_General-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Starfleet_Medical"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Starfleet_Medical">
+				<div class="vector-toc-text">
+				<span class="vector-toc-numb">3.7</span>Starfleet Medical</div>
+			</a>
+			
+			<ul id="toc-Starfleet_Medical-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Starfleet_Operations"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Starfleet_Operations">
+				<div class="vector-toc-text">
+				<span class="vector-toc-numb">3.8</span>Starfleet Operations</div>
+			</a>
+			
+			<ul id="toc-Starfleet_Operations-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Starfleet_Security"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Starfleet_Security">
+				<div class="vector-toc-text">
+				<span class="vector-toc-numb">3.9</span>Starfleet Security</div>
+			</a>
+			
+			<ul id="toc-Starfleet_Security-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Starfleet_Tactical"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Starfleet_Tactical">
+				<div class="vector-toc-text">
+				<span class="vector-toc-numb">3.10</span>Starfleet Tactical</div>
+			</a>
+			
+			<ul id="toc-Starfleet_Tactical-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+	</ul>
+	</li>
+	<li id="toc-Different_species_in_Starfleet"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Different_species_in_Starfleet">
+			<div class="vector-toc-text">
+			<span class="vector-toc-numb">4</span>Different species in Starfleet</div>
+		</a>
+		
+		<ul id="toc-Different_species_in_Starfleet-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-Insignia"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Insignia">
+			<div class="vector-toc-text">
+			<span class="vector-toc-numb">5</span>Insignia</div>
+		</a>
+		
+		<ul id="toc-Insignia-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-See_also"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#See_also">
+			<div class="vector-toc-text">
+			<span class="vector-toc-numb">6</span>See also</div>
+		</a>
+		
+		<ul id="toc-See_also-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-References"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#References">
+			<div class="vector-toc-text">
+			<span class="vector-toc-numb">7</span>References</div>
+		</a>
+		
+		<ul id="toc-References-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-External_links"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#External_links">
+			<div class="vector-toc-text">
+			<span class="vector-toc-numb">8</span>External links</div>
+		</a>
+		
+		<ul id="toc-External_links-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+</ul>
+</div>
+
+				</div>
+	</nav>
+		
+		<div class="mw-content-container">
+			<main id="content" class="mw-body" role="main">
+				<header class="mw-body-header vector-page-titlebar">
+					<nav role="navigation" aria-label="Contents" class="vector-toc-landmark">
+						
+<div id="vector-page-titlebar-toc" class="vector-dropdown vector-page-titlebar-toc vector-button-flush-left"  >
+	<input type="checkbox" id="vector-page-titlebar-toc-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-page-titlebar-toc" class="vector-dropdown-checkbox "  aria-label="Toggle the table of contents"  >
+	<label id="vector-page-titlebar-toc-label" for="vector-page-titlebar-toc-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-listBullet mw-ui-icon-wikimedia-listBullet"></span>
+
+<span class="vector-dropdown-label-text">Toggle the table of contents</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+							<div id="vector-page-titlebar-toc-unpinned-container" class="vector-unpinned-container">
+			</div>
+		
+	</div>
+</div>
+
+					</nav>
+					<h1 id="firstHeading" class="firstHeading mw-first-heading"><span class="mw-page-title-main">Starfleet</span></h1>
+							
+<div id="p-lang-btn" class="vector-dropdown mw-portlet mw-portlet-lang"  >
+	<input type="checkbox" id="p-lang-btn-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-p-lang-btn" class="vector-dropdown-checkbox mw-interlanguage-selector" aria-label="Go to an article in another language. Available in 33 languages"   >
+	<label id="p-lang-btn-label" for="p-lang-btn-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--action-progressive mw-portlet-lang-heading-33" aria-hidden="true"  ><span class="vector-icon mw-ui-icon-language-progressive mw-ui-icon-wikimedia-language-progressive"></span>
+
+<span class="vector-dropdown-label-text">33 languages</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+		<div class="vector-menu-content">
+			
+			<ul class="vector-menu-content-list">
+				
+				<li class="interlanguage-link interwiki-ar mw-list-item"><a href="https://ar.wikipedia.org/wiki/%D8%B3%D8%AA%D8%A7%D8%B1_%D9%81%D9%84%D9%8A%D8%AA_(%D8%B3%D8%AA%D8%A7%D8%B1_%D8%AA%D8%B1%D9%8A%D9%83)" title="ستار فليت (ستار تريك) – Arabic" lang="ar" hreflang="ar" class="interlanguage-link-target"><span>العربية</span></a></li><li class="interlanguage-link interwiki-bg mw-list-item"><a href="https://bg.wikipedia.org/wiki/%D0%97%D0%B2%D0%B5%D0%B7%D0%B4%D0%B5%D0%BD_%D1%84%D0%BB%D0%BE%D1%82" title="Звезден флот – Bulgarian" lang="bg" hreflang="bg" class="interlanguage-link-target"><span>Български</span></a></li><li class="interlanguage-link interwiki-bs mw-list-item"><a href="https://bs.wikipedia.org/wiki/Zvjezdana_flota" title="Zvjezdana flota – Bosnian" lang="bs" hreflang="bs" class="interlanguage-link-target"><span>Bosanski</span></a></li><li class="interlanguage-link interwiki-ca mw-list-item"><a href="https://ca.wikipedia.org/wiki/Flota_Estel%C2%B7lar" title="Flota Estel·lar – Catalan" lang="ca" hreflang="ca" class="interlanguage-link-target"><span>Català</span></a></li><li class="interlanguage-link interwiki-cs mw-list-item"><a href="https://cs.wikipedia.org/wiki/Hv%C4%9Bzdn%C3%A1_flotila" title="Hvězdná flotila – Czech" lang="cs" hreflang="cs" class="interlanguage-link-target"><span>Čeština</span></a></li><li class="interlanguage-link interwiki-de badge-Q70894304 mw-list-item" title=""><a href="https://de.wikipedia.org/wiki/Sternenflotte" title="Sternenflotte – German" lang="de" hreflang="de" class="interlanguage-link-target"><span>Deutsch</span></a></li><li class="interlanguage-link interwiki-es mw-list-item"><a href="https://es.wikipedia.org/wiki/Flota_Estelar" title="Flota Estelar – Spanish" lang="es" hreflang="es" class="interlanguage-link-target"><span>Español</span></a></li><li class="interlanguage-link interwiki-eo mw-list-item"><a href="https://eo.wikipedia.org/wiki/Stel%C5%9Diparo" title="Stelŝiparo – Esperanto" lang="eo" hreflang="eo" class="interlanguage-link-target"><span>Esperanto</span></a></li><li class="interlanguage-link interwiki-eu mw-list-item"><a href="https://eu.wikipedia.org/wiki/Izarretako_Flota" title="Izarretako Flota – Basque" lang="eu" hreflang="eu" class="interlanguage-link-target"><span>Euskara</span></a></li><li class="interlanguage-link interwiki-fa mw-list-item"><a href="https://fa.wikipedia.org/wiki/%D8%A7%D8%AE%D8%AA%D8%B1%D9%86%D8%A7%D9%88%DA%AF%D8%A7%D9%86" title="اخترناوگان – Persian" lang="fa" hreflang="fa" class="interlanguage-link-target"><span>فارسی</span></a></li><li class="interlanguage-link interwiki-fr mw-list-item"><a href="https://fr.wikipedia.org/wiki/Starfleet" title="Starfleet – French" lang="fr" hreflang="fr" class="interlanguage-link-target"><span>Français</span></a></li><li class="interlanguage-link interwiki-ko mw-list-item"><a href="https://ko.wikipedia.org/wiki/%EC%8A%A4%ED%83%80%ED%94%8C%EB%A6%BF" title="스타플릿 – Korean" lang="ko" hreflang="ko" class="interlanguage-link-target"><span>한국어</span></a></li><li class="interlanguage-link interwiki-hr mw-list-item"><a href="https://hr.wikipedia.org/wiki/Zvjezdana_flota" title="Zvjezdana flota – Croatian" lang="hr" hreflang="hr" class="interlanguage-link-target"><span>Hrvatski</span></a></li><li class="interlanguage-link interwiki-id mw-list-item"><a href="https://id.wikipedia.org/wiki/Starfleet" title="Starfleet – Indonesian" lang="id" hreflang="id" class="interlanguage-link-target"><span>Bahasa Indonesia</span></a></li><li class="interlanguage-link interwiki-it mw-list-item"><a href="https://it.wikipedia.org/wiki/Flotta_Stellare" title="Flotta Stellare – Italian" lang="it" hreflang="it" class="interlanguage-link-target"><span>Italiano</span></a></li><li class="interlanguage-link interwiki-he mw-list-item"><a href="https://he.wikipedia.org/wiki/%D7%A6%D7%99_%D7%94%D7%9B%D7%95%D7%9B%D7%91%D7%99%D7%9D" title="צי הכוכבים – Hebrew" lang="he" hreflang="he" class="interlanguage-link-target"><span>עברית</span></a></li><li class="interlanguage-link interwiki-ka mw-list-item"><a href="https://ka.wikipedia.org/wiki/%E1%83%95%E1%83%90%E1%83%A0%E1%83%A1%E1%83%99%E1%83%95%E1%83%9A%E1%83%90%E1%83%95%E1%83%A3%E1%83%A0%E1%83%98_%E1%83%A4%E1%83%9A%E1%83%9D%E1%83%A2%E1%83%98" title="ვარსკვლავური ფლოტი – Georgian" lang="ka" hreflang="ka" class="interlanguage-link-target"><span>ქართული</span></a></li><li class="interlanguage-link interwiki-lb mw-list-item"><a href="https://lb.wikipedia.org/wiki/Starfleet" title="Starfleet – Luxembourgish" lang="lb" hreflang="lb" class="interlanguage-link-target"><span>Lëtzebuergesch</span></a></li><li class="interlanguage-link interwiki-hu mw-list-item"><a href="https://hu.wikipedia.org/wiki/Csillagflotta" title="Csillagflotta – Hungarian" lang="hu" hreflang="hu" class="interlanguage-link-target"><span>Magyar</span></a></li><li class="interlanguage-link interwiki-mr mw-list-item"><a href="https://mr.wikipedia.org/wiki/%E0%A4%B8%E0%A5%8D%E0%A4%9F%E0%A4%BE%E0%A4%B0%E0%A4%AB%E0%A5%8D%E0%A4%B2%E0%A5%80%E0%A4%9F" title="स्टारफ्लीट – Marathi" lang="mr" hreflang="mr" class="interlanguage-link-target"><span>मराठी</span></a></li><li class="interlanguage-link interwiki-nl mw-list-item"><a href="https://nl.wikipedia.org/wiki/Starfleet" title="Starfleet – Dutch" lang="nl" hreflang="nl" class="interlanguage-link-target"><span>Nederlands</span></a></li><li class="interlanguage-link interwiki-ja badge-Q70893996 mw-list-item" title=""><a href="https://ja.wikipedia.org/wiki/%E5%AE%87%E5%AE%99%E8%89%A6%E9%9A%8A" title="宇宙艦隊 – Japanese" lang="ja" hreflang="ja" class="interlanguage-link-target"><span>日本語</span></a></li><li class="interlanguage-link interwiki-no mw-list-item"><a href="https://no.wikipedia.org/wiki/Starfleet" title="Starfleet – Norwegian Bokmål" lang="nb" hreflang="nb" class="interlanguage-link-target"><span>Norsk bokmål</span></a></li><li class="interlanguage-link interwiki-pl mw-list-item"><a href="https://pl.wikipedia.org/wiki/Gwiezdna_Flota" title="Gwiezdna Flota – Polish" lang="pl" hreflang="pl" class="interlanguage-link-target"><span>Polski</span></a></li><li class="interlanguage-link interwiki-pt badge-Q70893996 mw-list-item" title=""><a href="https://pt.wikipedia.org/wiki/Frota_Estelar" title="Frota Estelar – Portuguese" lang="pt" hreflang="pt" class="interlanguage-link-target"><span>Português</span></a></li><li class="interlanguage-link interwiki-ro mw-list-item"><a href="https://ro.wikipedia.org/wiki/Flota_Stelar%C4%83" title="Flota Stelară – Romanian" lang="ro" hreflang="ro" class="interlanguage-link-target"><span>Română</span></a></li><li class="interlanguage-link interwiki-ru mw-list-item"><a href="https://ru.wikipedia.org/wiki/%D0%97%D0%B2%D1%91%D0%B7%D0%B4%D0%BD%D1%8B%D0%B9_%D1%84%D0%BB%D0%BE%D1%82" title="Звёздный флот – Russian" lang="ru" hreflang="ru" class="interlanguage-link-target"><span>Русский</span></a></li><li class="interlanguage-link interwiki-simple mw-list-item"><a href="https://simple.wikipedia.org/wiki/Starfleet" title="Starfleet – Simple English" lang="en-simple" hreflang="en-simple" class="interlanguage-link-target"><span>Simple English</span></a></li><li class="interlanguage-link interwiki-sr mw-list-item"><a href="https://sr.wikipedia.org/wiki/Zvezdana_flota" title="Zvezdana flota – Serbian" lang="sr" hreflang="sr" class="interlanguage-link-target"><span>Српски / srpski</span></a></li><li class="interlanguage-link interwiki-sv mw-list-item"><a href="https://sv.wikipedia.org/wiki/Stj%C3%A4rnflottan" title="Stjärnflottan – Swedish" lang="sv" hreflang="sv" class="interlanguage-link-target"><span>Svenska</span></a></li><li class="interlanguage-link interwiki-tr mw-list-item"><a href="https://tr.wikipedia.org/wiki/Y%C4%B1ld%C4%B1z_Filosu" title="Yıldız Filosu – Turkish" lang="tr" hreflang="tr" class="interlanguage-link-target"><span>Türkçe</span></a></li><li class="interlanguage-link interwiki-uk mw-list-item"><a href="https://uk.wikipedia.org/wiki/%D0%97%D0%BE%D1%80%D1%8F%D0%BD%D0%B8%D0%B9_%D1%84%D0%BB%D0%BE%D1%82" title="Зоряний флот – Ukrainian" lang="uk" hreflang="uk" class="interlanguage-link-target"><span>Українська</span></a></li><li class="interlanguage-link interwiki-zh mw-list-item"><a href="https://zh.wikipedia.org/wiki/%E6%98%9F%E9%99%85%E8%88%B0%E9%98%9F" title="星际舰队 – Chinese" lang="zh" hreflang="zh" class="interlanguage-link-target"><span>中文</span></a></li>
+			</ul>
+			<div class="after-portlet after-portlet-lang"><span class="wb-langlinks-edit wb-langlinks-link"><a href="https://www.wikidata.org/wiki/Special:EntityPage/Q718644#sitelinks-wikipedia" title="Edit interlanguage links" class="wbc-editpage">Edit links</a></span></div>
+		</div>
+
+	</div>
+</div>
+</header>
+				<div class="vector-page-toolbar">
+					<div class="vector-page-toolbar-container">
+						<div id="left-navigation">
+							<nav aria-label="Namespaces">
+								
+<div id="p-associated-pages" class="vector-menu vector-menu-tabs mw-portlet mw-portlet-associated-pages"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-nstab-main" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/Starfleet" title="View the content page [c]" accesskey="c"><span>Article</span></a></li><li id="ca-talk" class="vector-tab-noicon mw-list-item"><a href="/wiki/Talk:Starfleet" rel="discussion" title="Discuss improvements to the content page [t]" accesskey="t"><span>Talk</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+								
+<div id="p-variants" class="vector-dropdown emptyPortlet"  >
+	<input type="checkbox" id="p-variants-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-p-variants" class="vector-dropdown-checkbox " aria-label="Change language variant"   >
+	<label id="p-variants-label" for="p-variants-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" aria-hidden="true"  ><span class="vector-dropdown-label-text">English</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+					
+<div id="p-variants" class="vector-menu mw-portlet mw-portlet-variants emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+				
+	</div>
+</div>
+
+							</nav>
+						</div>
+						<div id="right-navigation" class="vector-collapsible">
+							<nav aria-label="Views">
+								
+<div id="p-views" class="vector-menu vector-menu-tabs mw-portlet mw-portlet-views"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-view" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/Starfleet"><span>Read</span></a></li><li id="ca-edit" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Starfleet&amp;action=edit" title="Edit the source code of this page [e]" accesskey="e"><span>Edit</span></a></li><li id="ca-history" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Starfleet&amp;action=history" title="Past revisions of this page [h]" accesskey="h"><span>View history</span></a></li><li id="ca-watch" class="mw-watchlink mw-list-item"><a href="/w/index.php?title=Starfleet&amp;action=watch" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only" data-mw="interface" title="Add this page to your watchlist [w]" accesskey="w"><span class="vector-icon mw-ui-icon-star mw-ui-icon-wikimedia-star"></span> <span>Watch</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+							</nav>
+				
+							<nav class="vector-page-tools-landmark" aria-label="Page tools">
+								
+<div id="vector-page-tools-dropdown" class="vector-dropdown vector-page-tools-dropdown"  >
+	<input type="checkbox" id="vector-page-tools-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-page-tools-dropdown" class="vector-dropdown-checkbox "  aria-label="Tools"  >
+	<label id="vector-page-tools-dropdown-label" for="vector-page-tools-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" aria-hidden="true"  ><span class="vector-dropdown-label-text">Tools</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+									<div id="vector-page-tools-unpinned-container" class="vector-unpinned-container">
+						
+									</div>
+				
+	</div>
+</div>
+
+							</nav>
+						</div>
+					</div>
+				</div>
+				<div class="vector-column-end">
+					<nav class="vector-page-tools-landmark vector-sticky-pinned-container" aria-label="Page tools">
+						<div id="vector-page-tools-pinned-container" class="vector-pinned-container">
+			
+<div id="vector-page-tools" class="vector-page-tools vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-page-tools-pinnable-header vector-pinnable-header-pinned"
+	data-feature-name="page-tools-pinned"
+	data-pinnable-element-id="vector-page-tools"
+	data-pinned-container-id="vector-page-tools-pinned-container"
+	data-unpinned-container-id="vector-page-tools-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Tools</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-page-tools.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-page-tools.unpin">hide</button>
+</div>
+
+	
+<div id="p-cactions" class="vector-menu mw-portlet mw-portlet-cactions vector-has-collapsible-items"  title="More options" >
+	<div class="vector-menu-heading">
+		Actions
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-more-view" class="selected vector-more-collapsible-item mw-list-item"><a href="/wiki/Starfleet"><span>Read</span></a></li><li id="ca-more-edit" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Starfleet&amp;action=edit" title="Edit the source code of this page [e]" accesskey="e"><span>Edit</span></a></li><li id="ca-more-history" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Starfleet&amp;action=history"><span>View history</span></a></li><li id="ca-more-watch" class="mw-watchlink vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Starfleet&amp;action=watch" data-mw="interface"><span>Watch</span></a></li><li id="ca-move" class="mw-list-item"><a href="/wiki/Special:MovePage/Starfleet" title="Rename this page [m]" accesskey="m"><span>Move</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-tb" class="vector-menu mw-portlet mw-portlet-tb"  >
+	<div class="vector-menu-heading">
+		General
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="t-whatlinkshere" class="mw-list-item"><a href="/wiki/Special:WhatLinksHere/Starfleet" title="List of all English Wikipedia pages containing links to this page [j]" accesskey="j"><span>What links here</span></a></li><li id="t-recentchangeslinked" class="mw-list-item"><a href="/wiki/Special:RecentChangesLinked/Starfleet" rel="nofollow" title="Recent changes in pages linked from this page [k]" accesskey="k"><span>Related changes</span></a></li><li id="t-upload" class="mw-list-item"><a href="/wiki/Wikipedia:File_Upload_Wizard" title="Upload files [u]" accesskey="u"><span>Upload file</span></a></li><li id="t-specialpages" class="mw-list-item"><a href="/wiki/Special:SpecialPages" title="A list of all special pages [q]" accesskey="q"><span>Special pages</span></a></li><li id="t-permalink" class="mw-list-item"><a href="/w/index.php?title=Starfleet&amp;oldid=1182208104" title="Permanent link to this revision of this page"><span>Permanent link</span></a></li><li id="t-info" class="mw-list-item"><a href="/w/index.php?title=Starfleet&amp;action=info" title="More information about this page"><span>Page information</span></a></li><li id="t-cite" class="mw-list-item"><a href="/w/index.php?title=Special:CiteThisPage&amp;page=Starfleet&amp;id=1182208104&amp;wpFormIdentifier=titleform" title="Information on how to cite this page"><span>Cite this page</span></a></li><li id="t-urlshortener" class="mw-list-item"><a href="/w/index.php?title=Special:UrlShortener&amp;url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FStarfleet"><span>Get shortened URL</span></a></li><li id="t-wikibase" class="mw-list-item"><a href="https://www.wikidata.org/wiki/Special:EntityPage/Q718644" title="Structured data on this page hosted by Wikidata [g]" accesskey="g"><span>Wikidata item</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-coll-print_export" class="vector-menu mw-portlet mw-portlet-coll-print_export"  >
+	<div class="vector-menu-heading">
+		Print/export
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="coll-download-as-rl" class="mw-list-item"><a href="/w/index.php?title=Special:DownloadAsPdf&amp;page=Starfleet&amp;action=show-download-screen" title="Download this page as a PDF file"><span>Download as PDF</span></a></li><li id="t-print" class="mw-list-item"><a href="/w/index.php?title=Starfleet&amp;printable=yes" title="Printable version of this page [p]" accesskey="p"><span>Printable version</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+</div>
+
+						</div>
+	</nav>
+				</div>
+				<div id="bodyContent" class="vector-body" aria-labelledby="firstHeading" data-mw-ve-target-container>
+					<div class="vector-body-before-content">
+							<div class="mw-indicators">
+		</div>
+
+						<div id="siteSub" class="noprint">From Wikipedia, the free encyclopedia</div>
+					</div>
+					<div id="contentSub"><div id="mw-content-subtitle"></div></div>
+					
+					
+					<div id="mw-content-text" class="mw-body-content"><div class="mw-content-ltr mw-parser-output" lang="en" dir="ltr"><style data-mw-deduplicate="TemplateStyles:r1033289096">.mw-parser-output .hatnote{font-style:italic}.mw-parser-output div.hatnote{padding-left:1.6em;margin-bottom:0.5em}.mw-parser-output .hatnote i{font-style:normal}.mw-parser-output .hatnote+link+.hatnote{margin-top:-0.5em}</style><div role="note" class="hatnote navigation-not-searchable">This article is about the Starfleet organization in the Star Trek universe. For other uses, see <a href="/wiki/Starfleet_(disambiguation)" class="mw-disambig" title="Starfleet (disambiguation)">Starfleet (disambiguation)</a>.</div>
+<div class="shortdescription nomobile noexcerpt noprint searchaux" style="display:none">Fictional space flight organization</div>
+<style data-mw-deduplicate="TemplateStyles:r1066479718">.mw-parser-output .infobox-subbox{padding:0;border:none;margin:-3px;width:auto;min-width:100%;font-size:100%;clear:none;float:none;background-color:transparent}.mw-parser-output .infobox-3cols-child{margin:auto}.mw-parser-output .infobox .navbar{font-size:100%}body.skin-minerva .mw-parser-output .infobox-header,body.skin-minerva .mw-parser-output .infobox-subheader,body.skin-minerva .mw-parser-output .infobox-above,body.skin-minerva .mw-parser-output .infobox-title,body.skin-minerva .mw-parser-output .infobox-image,body.skin-minerva .mw-parser-output .infobox-full-data,body.skin-minerva .mw-parser-output .infobox-below{text-align:center}</style><table class="infobox" style="width:25.5em;border-spacing:2px;"><tbody><tr><th colspan="2" class="infobox-above" style="background-color:#C3D6EF;text-align:center;vertical-align:middle;font-size:110%;">Starfleet</th></tr><tr><th scope="row" class="infobox-label" style="padding-right: 1em;">Active</th><td class="infobox-data">2130s–32nd century (latest date known)</td></tr><tr><th scope="row" class="infobox-label" style="padding-right: 1em;">Country</th><td class="infobox-data"><span typeof="mw:File"><a href="/wiki/File:UFP_Flag.png" class="mw-file-description"><img src="//upload.wikimedia.org/wikipedia/commons/thumb/d/d2/UFP_Flag.png/23px-UFP_Flag.png" decoding="async" width="23" height="12" class="mw-file-element" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/d/d2/UFP_Flag.png/35px-UFP_Flag.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/d/d2/UFP_Flag.png/46px-UFP_Flag.png 2x" data-file-width="430" data-file-height="232" /></a></span> <a href="/wiki/United_Federation_of_Planets" title="United Federation of Planets">United Federation of Planets</a></td></tr><tr><th scope="row" class="infobox-label" style="padding-right: 1em;">Type</th><td class="infobox-data"><a href="/wiki/Paramilitary" title="Paramilitary">Paramilitary</a> organization<br /><a href="/wiki/Space_force" title="Space force">Space force</a><br /><a href="/wiki/Space_agency" class="mw-redirect" title="Space agency">Space agency</a></td></tr><tr><th scope="row" class="infobox-label" style="padding-right: 1em;">Role</th><td class="infobox-data"><a href="/wiki/Military" title="Military">Defense</a><br /><a href="/wiki/Internal_security" title="Internal security">Internal security</a><br /><a href="/wiki/Peacekeeping" title="Peacekeeping">Peacekeeping</a><br /><a href="/wiki/Law_enforcement" title="Law enforcement">Law enforcement</a><br /><a href="/wiki/Civil_defense" title="Civil defense">Civil defense</a><br /><a href="/wiki/Space_exploration" title="Space exploration">Space exploration</a><br /><a href="/wiki/Scientific_research" class="mw-redirect" title="Scientific research">Scientific research</a><br /><a href="/wiki/Diplomacy" title="Diplomacy">Diplomacy</a></td></tr><tr><th scope="row" class="infobox-label" style="padding-right: 1em;">Headquarters</th><td class="infobox-data"><a href="/wiki/San_Francisco" title="San Francisco">San Francisco</a>, <a href="/wiki/California" title="California">California</a>, United <a href="/wiki/Earth" title="Earth">Earth</a> (2130-3089), Federation Headquarters (3089-)</td></tr><tr><th scope="row" class="infobox-label" style="padding-right: 1em;">Engagements</th><td class="infobox-data">Xindi Conflict<br />Earth-Romulan War<br />Klingon-Federation Wars<br />Federation-Tzenkethi War<br />Federation-Cardassian War<br />Galen border conflict<br />Dominion War</td></tr><tr><th colspan="2" class="infobox-header" style="background-color:#C3D6EF;text-align:center;vertical-align:middle;font-size:110%;">Insignia</th></tr><tr><th scope="row" class="infobox-label" style="padding-right: 1em;">Standard Starfleet Symbol</th><td class="infobox-data"><span typeof="mw:File"><a href="/wiki/File:Delta-shield.svg" class="mw-file-description"><img src="//upload.wikimedia.org/wikipedia/commons/thumb/9/90/Delta-shield.svg/50px-Delta-shield.svg.png" decoding="async" width="50" height="81" class="mw-file-element" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/9/90/Delta-shield.svg/75px-Delta-shield.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/9/90/Delta-shield.svg/100px-Delta-shield.svg.png 2x" data-file-width="100" data-file-height="162" /></a></span></td></tr></tbody></table><div class="shortdescription nomobile noexcerpt noprint searchaux" style="display:none">Military unit</div>
+<p><b>Starfleet</b> is a fictional organization in the <i><a href="/wiki/Star_Trek" title="Star Trek">Star Trek</a></i> media franchise. Within this <a href="/wiki/Fictional_universe" title="Fictional universe">fictional universe</a>, Starfleet is a uniformed <a href="/wiki/Space_force" title="Space force">space force</a> maintained by the <a href="/wiki/United_Federation_of_Planets" title="United Federation of Planets">United Federation of Planets</a> ("the Federation") as the principal means for conducting deep space exploration, research, <a href="/wiki/Military" title="Military">defense</a>, <a href="/wiki/Peacekeeping" title="Peacekeeping">peacekeeping</a>, and diplomacy (although Starfleet predates the Federation, having originally been an Earth organization, as shown by the television series <i><a href="/wiki/Star_Trek:_Enterprise" title="Star Trek: Enterprise">Star Trek: Enterprise</a></i>). While most of Starfleet's members are human and it has been headquartered on Earth, hundreds of other species are also represented. Most of the franchise's protagonists are Starfleet <a href="/wiki/Officer_(armed_forces)" title="Officer (armed forces)">commissioned officers</a>.
+</p>
+<meta property="mw:PageProp/toc" />
+<h2><span class="mw-headline" id="History">History</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=1" title="Edit section: History"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>During production of early episodes of the <a href="/wiki/Star_Trek:_The_Original_Series" title="Star Trek: The Original Series">original series</a>, several details of the makeup of the <i><a href="/wiki/Star_Trek" title="Star Trek">Star Trek</a></i> universe had yet to be worked out, including the operating authority for the <a href="/wiki/USS_Enterprise_(NCC-1701)" title="USS Enterprise (NCC-1701)">USS <i>Enterprise</i></a>. The terms <i>Star Service</i> ("<a href="/wiki/The_Conscience_of_the_King" title="The Conscience of the King">The Conscience of the King</a>"), <i>Spacefleet Command</i> ("<a href="/wiki/The_Squire_of_Gothos" title="The Squire of Gothos">The Squire of Gothos</a>"), <i>United Earth Space Probe Agency</i> ("<a href="/wiki/Charlie_X" title="Charlie X">Charlie X</a>" and "<a href="/wiki/Tomorrow_Is_Yesterday" title="Tomorrow Is Yesterday">Tomorrow Is Yesterday</a>"), and <i>Space Central</i> ("<a href="/wiki/Miri_(Star_Trek:_The_Original_Series)" title="Miri (Star Trek: The Original Series)">Miri</a>") were all used to refer to the <i>Enterprise</i><span class="nowrap" style="padding-left:0.1em;">&#39;</span>s operating authority, before the term "Starfleet" became widespread from the episode "<a href="/wiki/Court_Martial_(Star_Trek:_The_Original_Series)" title="Court Martial (Star Trek: The Original Series)">Court Martial</a>" onwards.
+</p><p>However, references to the United Earth Space Probe Agency, and its abbreviation UESPA, are to be found in episodes of later series. For example, the <i>Friendship One</i> probe (launched, on the fictional timeline, in 2067) is marked with the letters UESPA-1 in the <i><a href="/wiki/Star_Trek:_Voyager" title="Star Trek: Voyager">Star Trek: Voyager</a></i> episode "<a href="/wiki/Friendship_One_(Star_Trek:_Voyager)" title="Friendship One (Star Trek: Voyager)">Friendship One</a>". Other background props included additional UESPA references, such as Captain <a href="/wiki/Jean-Luc_Picard" title="Jean-Luc Picard">Jean-Luc Picard</a>'s family album in <i><a href="/wiki/Star_Trek_Generations" title="Star Trek Generations">Star Trek Generations</a></i>. During the production of <i><a href="/wiki/Star_Trek:_Enterprise" title="Star Trek: Enterprise">Star Trek: Enterprise</a></i>, some larger Starfleet insignia designs included the name "United Earth Space Probe Agency".
+</p><p>Multiple <i>Star Trek: Enterprise</i> episodes refer to Starfleet having started operation some time between 2112 and 2136, when it funded research begun by Zefram Cochrane and Henry Archer, which led to the first successful flight of Warp-3 vessels in the 2140s. <sup id="cite_ref-1" class="reference"><a href="#cite_note-1">&#91;1&#93;</a></sup> This research is said to have evolved into the NX Program, which led to Starfleet launching its first Warp 5–capable starship, <a href="/wiki/Enterprise_(NX-01)" title="Enterprise (NX-01)"><i>Enterprise</i> (NX-01)</a>, in 2151, followed by <i>Columbia</i> (NX-02), in 2155, as well as other vessels.
+</p><p>Starfleet acts under the <a href="/wiki/Prime_Directive" title="Prime Directive">Prime Directive</a>, a policy of non-interference with pre-warp worlds, such as interference in their internal politics. This is said not to be a human construct, but stems from policies originally implemented by the Vulcans, who regarded an alien civilization's attainment of warp speed as the reason for making <a href="/wiki/First_contact_(science_fiction)" title="First contact (science fiction)">first contact</a> with them. This was to avoid any unfortunate incidences during space travel, as well as avoiding interfering in the natural development of a civilization. The Prime Directive and Starfleet's first-contact policies are at the center of several episodes in each <i>Star Trek</i> series and the film <i><a href="/wiki/Star_Trek:_First_Contact" title="Star Trek: First Contact">Star Trek: First Contact</a></i>.
+</p><p>Starfleet Headquarters is shown to be located on <a href="/wiki/Earth" title="Earth">Earth</a>, northeast of the <a href="/wiki/Golden_Gate_Bridge" title="Golden Gate Bridge">Golden Gate Bridge</a> in the present-day <a href="/wiki/Fort_Baker" title="Fort Baker">Fort Baker</a> area. <a href="/wiki/Starfleet_Academy" title="Starfleet Academy">Starfleet Academy</a> is located in the same general area.<sup id="cite_ref-2" class="reference"><a href="#cite_note-2">&#91;2&#93;</a></sup> Additionally, various episodes show Starfleet operating a series of starbases throughout Federation territory, as ground facilities, or as <a href="/wiki/Space_station" title="Space station">space stations</a> in planetary orbit or in deep space. One example is <a href="/wiki/Deep_Space_Nine_(fictional_space_station)" title="Deep Space Nine (fictional space station)">Deep Space 9</a>, a station near a <a href="/wiki/Wormhole" title="Wormhole">wormhole</a> commanded by Benjamin Sisko after its transfer from the Cardassian Empire.
+</p>
+<h2><span class="mw-headline" id="Mission">Mission</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=2" title="Edit section: Mission"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>Starfleet has been shown to handle <a href="/wiki/Scientific" class="mw-redirect" title="Scientific">scientific</a>, <a href="/wiki/Military" title="Military">defense</a>, and diplomatic missions, although its primary mandate seems to be peaceful exploration in the search for <a href="/wiki/Sentient" class="mw-redirect" title="Sentient">sentient</a> life, as seen in the mission statements of different incarnations of the USS <i>Enterprise</i>. The <a href="/wiki/Flagship" title="Flagship">flagship</a> of Starfleet is often considered to be the starship <a href="/wiki/Starship_Enterprise" title="Starship Enterprise">USS <i>Enterprise</i></a>.
+</p>
+<h2><span class="mw-headline" id="Components">Components</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=3" title="Edit section: Components"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>Starfleet has many components, including:
+</p>
+<h3><span class="mw-headline" id="Starfleet_Academy">Starfleet Academy</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=4" title="Edit section: Starfleet Academy"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1033289096"><div role="note" class="hatnote navigation-not-searchable">Main article: <a href="/wiki/Starfleet_Academy" title="Starfleet Academy">Starfleet Academy</a></div>
+<p>As early as the original <i><a href="/wiki/Star_Trek:_The_Original_Series" title="Star Trek: The Original Series">Star Trek</a></i>, characters refer to attending <b>Starfleet Academy</b>. Later series establish it as an officer training facility with a four-year educational program. The main campus is located near Starfleet Headquarters in what is now <a href="/wiki/Fort_Baker" title="Fort Baker">Fort Baker</a>, California.
+</p>
+<h3><span class="mw-headline" id="Starfleet_Command">Starfleet Command</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=5" title="Edit section: Starfleet Command"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><b>Starfleet Command</b> is the headquarters/command center of Starfleet. The term "Starfleet Command" is first used in <a href="/wiki/Star_Trek:_The_Original_Series" title="Star Trek: The Original Series"><i>TOS</i></a> episode "<a href="/wiki/Court_Martial_(Star_Trek:_The_Original_Series)" title="Court Martial (Star Trek: The Original Series)">Court Martial</a>". Its headquarters are depicted as being in Fort Baker, across the Golden Gate from San Francisco, in <i><a href="/wiki/Star_Trek:_The_Motion_Picture" title="Star Trek: The Motion Picture">Star Trek: The Motion Picture</a></i> and <i><a href="/wiki/Star_Trek_IV:_The_Voyage_Home" title="Star Trek IV: The Voyage Home">Star Trek IV: The Voyage Home</a></i>. Overlooking the Command from the other side of the Golden Gate is the permanent site of the <a href="/wiki/Federation_Council_(Star_Trek)" class="mw-redirect" title="Federation Council (Star Trek)">Council of the United Federation of Planets</a> in what is now the <a href="/wiki/Presidio_of_San_Francisco" title="Presidio of San Francisco">Presidio of San Francisco</a>. Throughout the <i><a href="/wiki/Star_Trek" title="Star Trek">Star Trek</a></i> franchise, the main characters' isolation from Starfleet Command compels them to make and act upon decisions without Starfleet Command's orders or information, particularly in <i><a href="/wiki/Star_Trek:_Voyager" title="Star Trek: Voyager">Voyager</a></i> when the main protagonists have no means of contacting Earth for several years.
+</p>
+<h3><span class="mw-headline" id="Starfleet_Shipyards">Starfleet Shipyards</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=6" title="Edit section: Starfleet Shipyards"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>StarTrek.com notes that many of Starfleet's ships are built on <a href="/wiki/Mare_Island" title="Mare Island">Mare Island</a> near San Francisco. It states:
+</p>
+<dl><dd>Located on San Francisco's Mare Island, with additional starship assembly facilities located in Earth orbit, Starfleet's San Francisco Navy Yards is the site where the USS <i>Enterprise</i> NCC-1701 was built in 2245. Captain Robert April, the <i>Enterprise</i><span class="nowrap" style="padding-left:0.1em;">&#39;</span>s first commanding officer, was present at the San Francisco Navy Yards when the vessel's major components were built and prepared for assembly in Starfleet's orbital drydock facilities (episode, "<a href="/wiki/The_Counter-Clock_Incident" title="The Counter-Clock Incident">The Counter-Clock Incident</a>").</dd></dl>
+<p>The <i><a href="/wiki/USS_Enterprise_(NCC-1701-D)" title="USS Enterprise (NCC-1701-D)">Enterprise-D</a></i> and <a href="/wiki/USS_Voyager_(Star_Trek)" title="USS Voyager (Star Trek)">USS <i>Voyager</i></a> are depicted to have been constructed at a shipyard named <a href="/wiki/Utopia_Planitia" title="Utopia Planitia">Utopia Planitia</a> in Mars orbit. Utopia Planitia served as Starfleet's main ship yards throughout a large portion of Starfleet's existence. After the <i>Enterprise-D</i> encountered the <a href="/wiki/Borg" title="Borg">Borg</a> in the episode "<a href="/wiki/Q_Who" title="Q Who">Q Who</a>" the size of the Utopia Planitia shipyards was doubled out of fear of a Borg strike. They were once again doubled after the Dominion threat became more evident. A devastating attack on these shipyards is a major plot point in <i><a href="/wiki/Star_Trek:_Picard" title="Star Trek: Picard">Star Trek: Picard</a>.</i>
+</p><p>In the <a href="/wiki/Star_Trek_(film)" title="Star Trek (film)">2009 film</a>, the <i><a href="/wiki/USS_Enterprise_(NCC-1701)" title="USS Enterprise (NCC-1701)">Enterprise</a></i> is shown under construction near <a href="/wiki/James_T._Kirk" title="James T. Kirk">James T. Kirk</a>'s home in Iowa. In the <a href="/wiki/Star_Trek_Into_Darkness" title="Star Trek Into Darkness">2013 sequel</a>, <a href="/wiki/Scotty_(Star_Trek)" title="Scotty (Star Trek)">Montgomery "Scotty" Scott</a> discovers a covert Starfleet facility, near Jupiter, that has built a much larger Federation warship, USS <i>Vengeance</i>.
+</p>
+<h3><span class="mw-headline" id="Starfleet_Engineering_Corps">Starfleet Engineering Corps</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=7" title="Edit section: Starfleet Engineering Corps"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>The <b>Starfleet Engineering Corps</b> (also called the <b>Starfleet Corps of Engineers</b>) is mentioned in several episodes in conjunction with projects such as hollowing out the underground laboratory complex inside the Regula I asteroid in <i><a href="/wiki/Star_Trek_II:_The_Wrath_of_Khan" title="Star Trek II: The Wrath of Khan">Star Trek II: The Wrath of Khan</a></i>, the design of the <i>Yellowstone</i>-class Runabout in the alternate timeline in the <i><a href="/wiki/Star_Trek:_Voyager" title="Star Trek: Voyager">Star Trek: Voyager</a></i> episode "<a href="/wiki/Non_Sequitur_(Star_Trek:_Voyager)" title="Non Sequitur (Star Trek: Voyager)">Non Sequitur</a>", and devising a defense against the <a href="/wiki/Breen_(Star_Trek)" title="Breen (Star Trek)">Breen</a> energy-dampening weapon in the <i><a href="/wiki/Star_Trek:_Deep_Space_Nine" title="Star Trek: Deep Space Nine">Star Trek: Deep Space Nine</a></i> episode "<a href="/wiki/When_It_Rains%E2%80%A6" title="When It Rains…">When It Rains...</a>" As a result of these successes, Starfleet engineers gained a reputation as the undisputed masters of technological adaptation and modification. As one minion of the <a href="/wiki/Dominion_(Star_Trek)" title="Dominion (Star Trek)">Dominion</a> in the <i>Star Trek: DS9</i> episode, "<a href="/wiki/Rocks_and_Shoals_(Star_Trek:_Deep_Space_Nine)" title="Rocks and Shoals (Star Trek: Deep Space Nine)">Rocks and Shoals</a>" notes, Starfleet engineers are reputed to be able to "Turn rocks into replicators."
+</p><p>Additionally, <a href="/wiki/Pocket_Books" title="Pocket Books">Pocket Books</a> has published a series of <a href="/wiki/EBook" class="mw-redirect" title="EBook">eBooks</a> and novels in the <i>Starfleet Corps of Engineers</i> series.
+</p>
+<h3><span class="mw-headline" id="Starfleet_Intelligence">Starfleet Intelligence</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=8" title="Edit section: Starfleet Intelligence"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><b>Starfleet Intelligence</b> is an <a href="/wiki/Intelligence_(information_gathering)" class="mw-redirect" title="Intelligence (information gathering)">intelligence</a> agency of the <a href="/wiki/United_Federation_of_Planets" title="United Federation of Planets">United Federation of Planets</a>. It is entrusted with foreign and domestic espionage, counter-espionage, and state security.
+</p>
+<link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1033289096"><div role="note" class="hatnote navigation-not-searchable">See also: <a href="/wiki/Section_31_(Star_Trek)" title="Section 31 (Star Trek)">Section 31 (Star Trek)</a></div>
+<h3><span class="mw-headline" id="Starfleet_Judge_Advocate_General">Starfleet Judge Advocate General</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=9" title="Edit section: Starfleet Judge Advocate General"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1033289096"><div role="note" class="hatnote navigation-not-searchable">Main article: <a href="/wiki/Law_in_Star_Trek" title="Law in Star Trek">Law in Star Trek</a></div>
+<p>The <b>Starfleet Judge Advocate General</b> (or <i>JAG</i>) is the branch charged with overseeing legal matters within Starfleet.<sup id="cite_ref-Star_Trek_Encyclopedia_3-0" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup> Several episodes revolve around or involve JAG officers and procedures:<sup id="cite_ref-Star_Trek_Encyclopedia_3-1" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup>
+</p>
+<ul><li><a href="/wiki/Captain_(Star_Trek)" class="mw-redirect" title="Captain (Star Trek)">Captain</a> <a href="/wiki/James_T._Kirk" title="James T. Kirk">James T. Kirk</a> is the defendant in the <a href="/wiki/Star_Trek:_The_Original_Series" title="Star Trek: The Original Series"><i>TOS</i></a> episode "<a href="/wiki/Court_Martial_(Star_Trek)" class="mw-redirect" title="Court Martial (Star Trek)">Court Martial</a>".<sup id="cite_ref-Star_Trek_Encyclopedia_3-2" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup></li>
+<li><a href="/wiki/Data_(Star_Trek)" title="Data (Star Trek)">Data</a> participates in a JAG hearing to determine whether he is Starfleet property in the <a href="/wiki/Star_Trek:_The_Next_Generation" title="Star Trek: The Next Generation"><i>TNG</i></a> episode "<a href="/wiki/The_Measure_of_a_Man_(Star_Trek:_The_Next_Generation)" title="The Measure of a Man (Star Trek: The Next Generation)">The Measure of a Man</a>".<sup id="cite_ref-Star_Trek_Encyclopedia_3-3" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup></li>
+<li>A hearing is held to decide whether to extradite <a href="/wiki/Worf" title="Worf">Worf</a> to the <a href="/wiki/Klingon" title="Klingon">Klingons</a> in the <i><a href="/wiki/DS9" class="mw-redirect" title="DS9">DS9</a></i> episode "<a href="/wiki/Rules_of_Engagement_(Star_Trek:_Deep_Space_Nine)" title="Rules of Engagement (Star Trek: Deep Space Nine)">Rules of Engagement</a>".<sup id="cite_ref-Star_Trek_Encyclopedia_3-4" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup></li>
+<li>In "<a href="/wiki/Doctor_Bashir,_I_Presume%3F" title="Doctor Bashir, I Presume?">Doctor Bashir, I Presume?</a>", a JAG <a href="/wiki/Star_Trek_uniforms" title="Star Trek uniforms">rear admiral</a> arranges for Richard Bashir's incarceration—and his son <a href="/wiki/Julian_Bashir" title="Julian Bashir">Julian Bashir</a>'s retention of a Starfleet commission—as punishment for the illegal <a href="/wiki/Genetic_engineering" title="Genetic engineering">genetic enhancements</a> given to Julian as a child.<sup id="cite_ref-Star_Trek_Encyclopedia_3-5" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup></li></ul>
+<p>Dialog in "Court Martial" reveals that a court-martial may be convened in the absence of any JAG officers by three presiding command-level officers.<sup id="cite_ref-TOS_Court_Martial_4-0" class="reference"><a href="#cite_note-TOS_Court_Martial-4">&#91;4&#93;</a></sup> Additionally, dialog in "The Measure of a Man" indicates that the loss of a starship automatically leads to a JAG court-martial. Courts-martial were held following the loss of the USS <i>Pegasus</i> and USS <i>Stargazer</i>.<sup id="cite_ref-Star_Trek_Encyclopedia_3-6" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup> In the <i>Voyager</i> episode "<a href="/wiki/Parallax_(Star_Trek:_Voyager)" title="Parallax (Star Trek: Voyager)">Parallax</a>", Tuvok states that <a href="/wiki/Kathryn_Janeway" title="Kathryn Janeway">the Captain</a> has the authority to conduct a court-martial on the ship, given the circumstance of the ship being isolated from the Federation.
+</p>
+<h3><span class="mw-headline" id="Starfleet_Medical">Starfleet Medical</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=10" title="Edit section: Starfleet Medical"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><b>Starfleet Medical</b> is the medical branch of Starfleet.<sup id="cite_ref-Star_Trek_Encyclopedia_3-7" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup>
+</p><p><a href="/wiki/Gates_McFadden" title="Gates McFadden">Gates McFadden</a>, who played Dr. <a href="/wiki/Beverly_Crusher" title="Beverly Crusher">Beverly Crusher</a>, left <i><a href="/wiki/Star_Trek:_The_Next_Generation" title="Star Trek: The Next Generation">Star Trek: The Next Generation</a></i> during its second season.<sup id="cite_ref-Star_Trek_Encyclopedia_3-8" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup> The character is described during this season, and after her return, as having been assigned to Starfleet Medical.<sup id="cite_ref-Star_Trek_Encyclopedia_3-9" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup>
+</p>
+<h3><span class="mw-headline" id="Starfleet_Operations">Starfleet Operations</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=11" title="Edit section: Starfleet Operations"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>Numerous star ship dedication plaques identify other personnel associated with <b>Starfleet Operations</b>.<sup id="cite_ref-Star_Trek_Encyclopedia_3-10" class="reference"><a href="#cite_note-Star_Trek_Encyclopedia-3">&#91;3&#93;</a></sup> <a href="/wiki/Star_Trek_uniforms" title="Star Trek uniforms">Rear Admiral</a> <a href="/wiki/James_T._Kirk" title="James T. Kirk">James T. Kirk</a> served 18 months as Starfleet's Chief of Operations.<sup id="cite_ref-TMP_5-0" class="reference"><a href="#cite_note-TMP-5">&#91;5&#93;</a></sup>
+</p>
+<h3><span class="mw-headline" id="Starfleet_Security">Starfleet Security</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=12" title="Edit section: Starfleet Security"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><b>Starfleet Security</b> is an agency of Starfleet referred to in several episodes of <i><a href="/wiki/Star_Trek:_The_Next_Generation" title="Star Trek: The Next Generation">Star Trek: The Next Generation</a></i> and <i><a href="/wiki/Star_Trek:_Deep_Space_Nine" title="Star Trek: Deep Space Nine">Star Trek: Deep Space Nine</a></i>. Security is a branch of Starfleet first introduced in the <a href="/wiki/Star_Trek:_The_Original_Series" title="Star Trek: The Original Series">original <i>Star Trek</i></a>. Main characters in subsequent series have been security officers.
+</p>
+<h3><span class="mw-headline" id="Starfleet_Tactical">Starfleet Tactical</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=13" title="Edit section: Starfleet Tactical"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><b>Starfleet Tactical</b> is a rarely mentioned department in Starfleet that is responsible for planning defensive strategies, as well as engaging in weapons research and development.
+</p>
+<h2><span class="mw-headline" id="Different_species_in_Starfleet">Different species in Starfleet</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=14" title="Edit section: Different species in Starfleet"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>Although Humans are the most-often-seen crew members onscreen, Starfleet is shown to be composed of individuals from over 150 species, with <a href="/wiki/Vulcan_(Star_Trek)" title="Vulcan (Star Trek)">Vulcans</a> perhaps being the most common aliens seen.
+</p><p>Already in <i><a href="/wiki/Star_Trek:_The_Original_Series" title="Star Trek: The Original Series">TOS</a></i>, the USS <i>Enterprise</i> and other ships have a mixed-species crew, although this does not appear to be an absolute rule; for instance, the episode "<a href="/wiki/The_Immunity_Syndrome_(Star_Trek:_The_Original_Series)" title="The Immunity Syndrome (Star Trek: The Original Series)">The Immunity Syndrome</a>" refers to the USS <i>Intrepid</i> as having an all-Vulcan crew. The <i><a href="/wiki/Star_Trek:_Deep_Space_Nine" title="Star Trek: Deep Space Nine">Star Trek: Deep Space Nine</a></i> episode "<a href="/wiki/Take_Me_Out_to_the_Holosuite" title="Take Me Out to the Holosuite">Take Me Out to the Holosuite</a>" also features such a crew, serving aboard the USS <i>T'Kumbra</i>.
+</p><p>In keeping with this idea, <i><a href="/wiki/Star_Trek:_Enterprise" title="Star Trek: Enterprise">Star Trek: Enterprise</a></i>, in its first two seasons, was the only show to have an entirely human crew, as it was set before the formation of the <a href="/wiki/United_Federation_of_Planets" title="United Federation of Planets">Federation</a>, although the vessel did carry <a href="/wiki/Phlox_(Star_Trek)" title="Phlox (Star Trek)">Phlox</a>, a Denobulan serving in a medical exchange program, and <a href="/wiki/T%27Pol" title="T&#39;Pol">T'Pol</a>, then serving as an observer from the Vulcan High Command.
+</p><p><i><a href="/wiki/Star_Trek:_The_Next_Generation" title="Star Trek: The Next Generation">Star Trek: The Next Generation</a></i> saw the introduction of Starfleet's first <a href="/wiki/Klingon" title="Klingon">Klingon</a> officer. Other races—such as Bolians, Betazoids, and Trill—were seen, and given more central roles, in later series; some of these, notably Klingons, had been shown as enemies in earlier episodes.
+</p><p>Various episodes show that <a href="/wiki/Earth" title="Earth">Earth</a>/Federation citizenship is not a necessary pre-condition for joining Starfleet. <a href="/wiki/T%27Pol" title="T&#39;Pol">T'Pol</a> of Vulcan is shown to be the first non-human Starfleet officer, receiving a commission as a commander following the <a href="/wiki/Xindi_(Star_Trek)" class="mw-redirect" title="Xindi (Star Trek)">Xindi</a> mission and her resignation from the Vulcan High Command. Even after the Federation's formation citizenship was not required; several officers are from planets that are not part of the Federation. For example, <i>Star Trek: TNG</i><span class="nowrap" style="padding-left:0.1em;">&#39;</span>s Ensign <a href="/wiki/Ro_Laren" title="Ro Laren">Ro Laren</a>, a Bajoran aboard the <a href="/wiki/USS_Enterprise_(NCC-1701-D)" title="USS Enterprise (NCC-1701-D)">USS <i>Enterprise</i>-D</a>; her fellow <a href="/wiki/Bajoran" title="Bajoran">Bajoran</a> <a href="/wiki/Kira_Nerys" title="Kira Nerys">Kira Nerys</a>, who was field-commissioned as a Starfleet commander so that she could aid the <a href="/wiki/Cardassian" title="Cardassian">Cardassian</a> resistance during the <a href="/wiki/Dominion_War" title="Dominion War">Dominion War</a>; and <a href="/wiki/Ferengi" title="Ferengi">Ferengi</a> <a href="/wiki/Nog_(Star_Trek)" title="Nog (Star Trek)">Nog</a>, who enters Starfleet Academy in season four of Deep Space Nine; all were from non-member planets. In addition, Quinn and Icheb from <i><a href="/wiki/Star_Trek:_Voyager" title="Star Trek: Voyager">Star Trek: Voyager</a></i> both spoke of joining Starfleet.
+</p><p>An example of the process imagined by the writers is given when the character <a href="/wiki/Nog_(Star_Trek)" title="Nog (Star Trek)">Nog</a> attempts to apply to the <a href="/wiki/Starfleet_Academy" title="Starfleet Academy">Academy</a>. He is told that since he is from a non-member world (Ferenginar), he requires a letter of recommendation from a command-level officer before his application can be considered, with the implication that this is the standard procedure for all non-Federation applicants to Starfleet.
+</p><p>In the <i>Star Trek</i> Expanded Universe, an example of what typically becomes of a new Federation member world's military is depicted when the <a href="/wiki/Bajoran#Bajoran_Militia" title="Bajoran">Bajoran Militia</a> is integrated into Starfleet upon Bajor's entry into the Federation.
+</p>
+<h2><span class="mw-headline" id="Insignia">Insignia</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=15" title="Edit section: Insignia"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>The Starfleet insignia have been inspired by the in aeronautics broadly used <a href="/wiki/Chevron_(insignia)" title="Chevron (insignia)">chevron</a>, and particularly by the <a href="/wiki/NASA_insignia" title="NASA insignia">insignia of NASA</a>.<sup id="cite_ref-FACT_TREK_2021_c936_6-0" class="reference"><a href="#cite_note-FACT_TREK_2021_c936-6">&#91;6&#93;</a></sup><sup id="cite_ref-Cooley_2023_l186_7-0" class="reference"><a href="#cite_note-Cooley_2023_l186-7">&#91;7&#93;</a></sup><sup id="cite_ref-Burrows_2020_u339_8-0" class="reference"><a href="#cite_note-Burrows_2020_u339-8">&#91;8&#93;</a></sup>
+</p>
+<figure class="mw-halign-right" typeof="mw:File/Thumb"><a href="/wiki/File:NASA-Mars-$tarTrekFleetLogo-20190612.jpg" class="mw-file-description"><img src="//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/NASA-Mars-%24tarTrekFleetLogo-20190612.jpg/125px-NASA-Mars-%24tarTrekFleetLogo-20190612.jpg" decoding="async" width="125" height="94" class="mw-file-element" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/d/d0/NASA-Mars-%24tarTrekFleetLogo-20190612.jpg/188px-NASA-Mars-%24tarTrekFleetLogo-20190612.jpg 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/d/d0/NASA-Mars-%24tarTrekFleetLogo-20190612.jpg/250px-NASA-Mars-%24tarTrekFleetLogo-20190612.jpg 2x" data-file-width="1800" data-file-height="1350" /></a><figcaption><a href="/wiki/Martian_soil" title="Martian soil">Dunes</a> on <a href="/wiki/Mars" title="Mars">Mars</a> look like the Starfleet emblem.<sup id="cite_ref-CNET-20190612_9-0" class="reference"><a href="#cite_note-CNET-20190612-9">&#91;9&#93;</a></sup><sup id="cite_ref-TT-20190616_10-0" class="reference"><a href="#cite_note-TT-20190616-10">&#91;10&#93;</a></sup></figcaption></figure>
+<h2><span class="mw-headline" id="See_also">See also</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=16" title="Edit section: See also"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<ul><li><a href="/wiki/Star_Trek_uniforms" title="Star Trek uniforms"><i>Star Trek</i> uniforms</a></li></ul>
+<h2><span class="mw-headline" id="References">References</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=17" title="Edit section: References"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<style data-mw-deduplicate="TemplateStyles:r1011085734">.mw-parser-output .reflist{font-size:90%;margin-bottom:0.5em;list-style-type:decimal}.mw-parser-output .reflist .references{font-size:100%;margin-bottom:0;list-style-type:inherit}.mw-parser-output .reflist-columns-2{column-width:30em}.mw-parser-output .reflist-columns-3{column-width:25em}.mw-parser-output .reflist-columns{margin-top:0.3em}.mw-parser-output .reflist-columns ol{margin-top:0}.mw-parser-output .reflist-columns li{page-break-inside:avoid;break-inside:avoid-column}.mw-parser-output .reflist-upper-alpha{list-style-type:upper-alpha}.mw-parser-output .reflist-upper-roman{list-style-type:upper-roman}.mw-parser-output .reflist-lower-alpha{list-style-type:lower-alpha}.mw-parser-output .reflist-lower-greek{list-style-type:lower-greek}.mw-parser-output .reflist-lower-roman{list-style-type:lower-roman}</style><div class="reflist reflist-columns references-column-width" style="column-width: 30em;">
+<ol class="references">
+<li id="cite_note-1"><span class="mw-cite-backlink"><b><a href="#cite_ref-1">^</a></b></span> <span class="reference-text">According to <a href="/wiki/Twilight_(Star_Trek:_Enterprise)" title="Twilight (Star Trek: Enterprise)">Twilight</a>, Starfleet was already established when Jonathan Archer was 24 years old (2136). According to <a href="/wiki/Horizon_(Star_Trek:_Enterprise)" title="Horizon (Star Trek: Enterprise)">Horizon</a> Starfleet was chartered during Jonathan Archers lifetime, after he considered working for the <a href="/w/index.php?title=Earth_Cargo_Service&amp;action=edit&amp;redlink=1" class="new" title="Earth Cargo Service (page does not exist)">Earth Cargo Service</a>.</span>
+</li>
+<li id="cite_note-2"><span class="mw-cite-backlink"><b><a href="#cite_ref-2">^</a></b></span> <span class="reference-text"><style data-mw-deduplicate="TemplateStyles:r1133582631">.mw-parser-output cite.citation{font-style:inherit;word-wrap:break-word}.mw-parser-output .citation q{quotes:"\"""\"""'""'"}.mw-parser-output .citation:target{background-color:rgba(0,127,255,0.133)}.mw-parser-output .id-lock-free a,.mw-parser-output .citation .cs1-lock-free a{background:url("//upload.wikimedia.org/wikipedia/commons/6/65/Lock-green.svg")right 0.1em center/9px no-repeat}.mw-parser-output .id-lock-limited a,.mw-parser-output .id-lock-registration a,.mw-parser-output .citation .cs1-lock-limited a,.mw-parser-output .citation .cs1-lock-registration a{background:url("//upload.wikimedia.org/wikipedia/commons/d/d6/Lock-gray-alt-2.svg")right 0.1em center/9px no-repeat}.mw-parser-output .id-lock-subscription a,.mw-parser-output .citation .cs1-lock-subscription a{background:url("//upload.wikimedia.org/wikipedia/commons/a/aa/Lock-red-alt-2.svg")right 0.1em center/9px no-repeat}.mw-parser-output .cs1-ws-icon a{background:url("//upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg")right 0.1em center/12px no-repeat}.mw-parser-output .cs1-code{color:inherit;background:inherit;border:none;padding:inherit}.mw-parser-output .cs1-hidden-error{display:none;color:#d33}.mw-parser-output .cs1-visible-error{color:#d33}.mw-parser-output .cs1-maint{display:none;color:#3a3;margin-left:0.3em}.mw-parser-output .cs1-format{font-size:95%}.mw-parser-output .cs1-kern-left{padding-left:0.2em}.mw-parser-output .cs1-kern-right{padding-right:0.2em}.mw-parser-output .citation .mw-selflink{font-weight:inherit}</style><cite id="CITEREFRuditis2016" class="citation book cs1">Ruditis, Paul (2016). <i>The Star Trek Book: Big Ideas Simply Explained</i>. Penguin. <a href="/wiki/ISBN_(identifier)" class="mw-redirect" title="ISBN (identifier)">ISBN</a>&#160;<a href="/wiki/Special:BookSources/9781465459770" title="Special:BookSources/9781465459770"><bdi>9781465459770</bdi></a>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&amp;rft.genre=book&amp;rft.btitle=The+Star+Trek+Book%3A+Big+Ideas+Simply+Explained&amp;rft.pub=Penguin&amp;rft.date=2016&amp;rft.isbn=9781465459770&amp;rft.aulast=Ruditis&amp;rft.aufirst=Paul&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AStarfleet" class="Z3988"></span></span>
+</li>
+<li id="cite_note-Star_Trek_Encyclopedia-3"><span class="mw-cite-backlink">^ <a href="#cite_ref-Star_Trek_Encyclopedia_3-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-Star_Trek_Encyclopedia_3-1"><sup><i><b>b</b></i></sup></a> <a href="#cite_ref-Star_Trek_Encyclopedia_3-2"><sup><i><b>c</b></i></sup></a> <a href="#cite_ref-Star_Trek_Encyclopedia_3-3"><sup><i><b>d</b></i></sup></a> <a href="#cite_ref-Star_Trek_Encyclopedia_3-4"><sup><i><b>e</b></i></sup></a> <a href="#cite_ref-Star_Trek_Encyclopedia_3-5"><sup><i><b>f</b></i></sup></a> <a href="#cite_ref-Star_Trek_Encyclopedia_3-6"><sup><i><b>g</b></i></sup></a> <a href="#cite_ref-Star_Trek_Encyclopedia_3-7"><sup><i><b>h</b></i></sup></a> <a href="#cite_ref-Star_Trek_Encyclopedia_3-8"><sup><i><b>i</b></i></sup></a> <a href="#cite_ref-Star_Trek_Encyclopedia_3-9"><sup><i><b>j</b></i></sup></a> <a href="#cite_ref-Star_Trek_Encyclopedia_3-10"><sup><i><b>k</b></i></sup></a></span> <span class="reference-text"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1133582631"><cite id="CITEREFOkudaOkuda1999" class="citation book cs1">Okuda, Michael; Okuda, Denise (1999). <i><a href="/wiki/The_Star_Trek_Encyclopedia" title="The Star Trek Encyclopedia">The Star Trek Encyclopedia&#160;: A Reference Guide to the Future</a></i> (Updated and expanded&#160;ed.). New York: Pocket Books. <a href="/wiki/ISBN_(identifier)" class="mw-redirect" title="ISBN (identifier)">ISBN</a>&#160;<a href="/wiki/Special:BookSources/0-671-03475-8" title="Special:BookSources/0-671-03475-8"><bdi>0-671-03475-8</bdi></a>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&amp;rft.genre=book&amp;rft.btitle=The+Star+Trek+Encyclopedia+%3A+A+Reference+Guide+to+the+Future&amp;rft.place=New+York&amp;rft.edition=Updated+and+expanded&amp;rft.pub=Pocket+Books&amp;rft.date=1999&amp;rft.isbn=0-671-03475-8&amp;rft.aulast=Okuda&amp;rft.aufirst=Michael&amp;rft.au=Okuda%2C+Denise&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AStarfleet" class="Z3988"></span></span>
+</li>
+<li id="cite_note-TOS_Court_Martial-4"><span class="mw-cite-backlink"><b><a href="#cite_ref-TOS_Court_Martial_4-0">^</a></b></span> <span class="reference-text"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1133582631"><cite class="citation episode cs1">"<a href="/wiki/The_Menagerie_(Star_Trek:_The_Original_Series)" title="The Menagerie (Star Trek: The Original Series)">The Menagerie</a>". <i><a href="/wiki/Star_Trek:_The_Original_Series" title="Star Trek: The Original Series">Star Trek</a></i>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&amp;rft.genre=unknown&amp;rft.btitle=Star+Trek&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AStarfleet" class="Z3988"></span></span>
+</li>
+<li id="cite_note-TMP-5"><span class="mw-cite-backlink"><b><a href="#cite_ref-TMP_5-0">^</a></b></span> <span class="reference-text"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1133582631"><cite class="citation audio-visual cs1"><i><span></span></i><a href="/wiki/Star_Trek:_The_Motion_Picture" title="Star Trek: The Motion Picture">Star Trek: The Motion Picture</a><i><span></span></i>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&amp;rft.genre=unknown&amp;rft.btitle=Star+Trek%3A+The+Motion+Picture&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AStarfleet" class="Z3988"></span></span>
+</li>
+<li id="cite_note-FACT_TREK_2021_c936-6"><span class="mw-cite-backlink"><b><a href="#cite_ref-FACT_TREK_2021_c936_6-0">^</a></b></span> <span class="reference-text"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1133582631"><cite class="citation web cs1"><a rel="nofollow" class="external text" href="https://www.facttrek.com/blog/emblematic">"Emblem-atic"</a>. <i>FACT TREK</i>. 2021-10-06<span class="reference-accessdate">. Retrieved <span class="nowrap">2023-10-14</span></span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=unknown&amp;rft.jtitle=FACT+TREK&amp;rft.atitle=Emblem-atic&amp;rft.date=2021-10-06&amp;rft_id=https%3A%2F%2Fwww.facttrek.com%2Fblog%2Femblematic&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AStarfleet" class="Z3988"></span></span>
+</li>
+<li id="cite_note-Cooley_2023_l186-7"><span class="mw-cite-backlink"><b><a href="#cite_ref-Cooley_2023_l186_7-0">^</a></b></span> <span class="reference-text"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1133582631"><cite id="CITEREFCooley2023" class="citation web cs1">Cooley, John (2023-07-24). <a rel="nofollow" class="external text" href="https://www.startrek.com/news/starfleet-insignia-explained">"The Starfleet Insignia Explained"</a>. <i>Star Trek</i><span class="reference-accessdate">. Retrieved <span class="nowrap">2023-10-14</span></span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=unknown&amp;rft.jtitle=Star+Trek&amp;rft.atitle=The+Starfleet+Insignia+Explained&amp;rft.date=2023-07-24&amp;rft.aulast=Cooley&amp;rft.aufirst=John&amp;rft_id=https%3A%2F%2Fwww.startrek.com%2Fnews%2Fstarfleet-insignia-explained&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AStarfleet" class="Z3988"></span></span>
+</li>
+<li id="cite_note-Burrows_2020_u339-8"><span class="mw-cite-backlink"><b><a href="#cite_ref-Burrows_2020_u339_8-0">^</a></b></span> <span class="reference-text"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1133582631"><cite id="CITEREFBurrows2020" class="citation web cs1">Burrows, Jillian Ada (2020-05-20). <a rel="nofollow" class="external text" href="https://medium.com/jill-burrows/star-trek-or-us-space-force-251a7494ad5f">"Star Trek or US Space Force?. Let us settle this debate once and for… — Jill Burrows"</a>. <i>Medium</i><span class="reference-accessdate">. Retrieved <span class="nowrap">2023-10-14</span></span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=unknown&amp;rft.jtitle=Medium&amp;rft.atitle=Star+Trek+or+US+Space+Force%3F.+Let+us+settle+this+debate+once+and+for%E2%80%A6+%E2%80%94+Jill+Burrows&amp;rft.date=2020-05-20&amp;rft.aulast=Burrows&amp;rft.aufirst=Jillian+Ada&amp;rft_id=https%3A%2F%2Fmedium.com%2Fjill-burrows%2Fstar-trek-or-us-space-force-251a7494ad5f&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AStarfleet" class="Z3988"></span></span>
+</li>
+<li id="cite_note-CNET-20190612-9"><span class="mw-cite-backlink"><b><a href="#cite_ref-CNET-20190612_9-0">^</a></b></span> <span class="reference-text"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1133582631"><cite id="CITEREFKooser2019" class="citation news cs1">Kooser, Amanda (June 12, 2019). <a rel="nofollow" class="external text" href="https://www.cnet.com/news/star-trek-on-mars-nasa-spots-starfleet-logo-in-dune-footprint/">"Star Trek on Mars: NASA spots Starfleet logo in dune footprint - Beam me down to Mars, Scotty"</a>. <i><a href="/wiki/CNET" title="CNET">CNET</a></i><span class="reference-accessdate">. Retrieved <span class="nowrap">June 16,</span> 2019</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=article&amp;rft.jtitle=CNET&amp;rft.atitle=Star+Trek+on+Mars%3A+NASA+spots+Starfleet+logo+in+dune+footprint+-+Beam+me+down+to+Mars%2C+Scotty.&amp;rft.date=2019-06-12&amp;rft.aulast=Kooser&amp;rft.aufirst=Amanda&amp;rft_id=https%3A%2F%2Fwww.cnet.com%2Fnews%2Fstar-trek-on-mars-nasa-spots-starfleet-logo-in-dune-footprint%2F&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AStarfleet" class="Z3988"></span></span>
+</li>
+<li id="cite_note-TT-20190616-10"><span class="mw-cite-backlink"><b><a href="#cite_ref-TT-20190616_10-0">^</a></b></span> <span class="reference-text"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1133582631"><cite id="CITEREFSamson2019" class="citation news cs1">Samson, Diane (June 16, 2019). <a rel="nofollow" class="external text" href="https://www.techtimes.com/articles/244331/20190615/william-shatner-takes-playful-jab-at-star-wars-over-starfleet-symbol-found-on-mars.htm">"William Shatner Takes Playful Jab At 'Star Wars' Over 'Starfleet' Symbol Found On Mars"</a>. <i>TechTimes.com</i><span class="reference-accessdate">. Retrieved <span class="nowrap">June 16,</span> 2019</span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=article&amp;rft.jtitle=TechTimes.com&amp;rft.atitle=William+Shatner+Takes+Playful+Jab+At+%27Star+Wars%27+Over+%27Starfleet%27+Symbol+Found+On+Mars&amp;rft.date=2019-06-16&amp;rft.aulast=Samson&amp;rft.aufirst=Diane&amp;rft_id=https%3A%2F%2Fwww.techtimes.com%2Farticles%2F244331%2F20190615%2Fwilliam-shatner-takes-playful-jab-at-star-wars-over-starfleet-symbol-found-on-mars.htm&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AStarfleet" class="Z3988"></span></span>
+</li>
+</ol></div>
+<h2><span class="mw-headline" id="External_links">External links</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Starfleet&amp;action=edit&amp;section=18" title="Edit section: External links"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<ul><li><a rel="nofollow" class="external text" href="https://memory-alpha.fandom.com/wiki/Starfleet">Starfleet</a> at <a href="/wiki/Memory_Alpha" title="Memory Alpha">Memory Alpha</a></li></ul>
+<div class="navbox-styles"><style data-mw-deduplicate="TemplateStyles:r1129693374">.mw-parser-output .hlist dl,.mw-parser-output .hlist ol,.mw-parser-output .hlist ul{margin:0;padding:0}.mw-parser-output .hlist dd,.mw-parser-output .hlist dt,.mw-parser-output .hlist li{margin:0;display:inline}.mw-parser-output .hlist.inline,.mw-parser-output .hlist.inline dl,.mw-parser-output .hlist.inline ol,.mw-parser-output .hlist.inline ul,.mw-parser-output .hlist dl dl,.mw-parser-output .hlist dl ol,.mw-parser-output .hlist dl ul,.mw-parser-output .hlist ol dl,.mw-parser-output .hlist ol ol,.mw-parser-output .hlist ol ul,.mw-parser-output .hlist ul dl,.mw-parser-output .hlist ul ol,.mw-parser-output .hlist ul ul{display:inline}.mw-parser-output .hlist .mw-empty-li{display:none}.mw-parser-output .hlist dt::after{content:": "}.mw-parser-output .hlist dd::after,.mw-parser-output .hlist li::after{content:" · ";font-weight:bold}.mw-parser-output .hlist dd:last-child::after,.mw-parser-output .hlist dt:last-child::after,.mw-parser-output .hlist li:last-child::after{content:none}.mw-parser-output .hlist dd dd:first-child::before,.mw-parser-output .hlist dd dt:first-child::before,.mw-parser-output .hlist dd li:first-child::before,.mw-parser-output .hlist dt dd:first-child::before,.mw-parser-output .hlist dt dt:first-child::before,.mw-parser-output .hlist dt li:first-child::before,.mw-parser-output .hlist li dd:first-child::before,.mw-parser-output .hlist li dt:first-child::before,.mw-parser-output .hlist li li:first-child::before{content:" (";font-weight:normal}.mw-parser-output .hlist dd dd:last-child::after,.mw-parser-output .hlist dd dt:last-child::after,.mw-parser-output .hlist dd li:last-child::after,.mw-parser-output .hlist dt dd:last-child::after,.mw-parser-output .hlist dt dt:last-child::after,.mw-parser-output .hlist dt li:last-child::after,.mw-parser-output .hlist li dd:last-child::after,.mw-parser-output .hlist li dt:last-child::after,.mw-parser-output .hlist li li:last-child::after{content:")";font-weight:normal}.mw-parser-output .hlist ol{counter-reset:listitem}.mw-parser-output .hlist ol>li{counter-increment:listitem}.mw-parser-output .hlist ol>li::before{content:" "counter(listitem)"\a0 "}.mw-parser-output .hlist dd ol>li:first-child::before,.mw-parser-output .hlist dt ol>li:first-child::before,.mw-parser-output .hlist li ol>li:first-child::before{content:" ("counter(listitem)"\a0 "}</style><style data-mw-deduplicate="TemplateStyles:r1061467846">.mw-parser-output .navbox{box-sizing:border-box;border:1px solid #a2a9b1;width:100%;clear:both;font-size:88%;text-align:center;padding:1px;margin:1em auto 0}.mw-parser-output .navbox .navbox{margin-top:0}.mw-parser-output .navbox+.navbox,.mw-parser-output .navbox+.navbox-styles+.navbox{margin-top:-1px}.mw-parser-output .navbox-inner,.mw-parser-output .navbox-subgroup{width:100%}.mw-parser-output .navbox-group,.mw-parser-output .navbox-title,.mw-parser-output .navbox-abovebelow{padding:0.25em 1em;line-height:1.5em;text-align:center}.mw-parser-output .navbox-group{white-space:nowrap;text-align:right}.mw-parser-output .navbox,.mw-parser-output .navbox-subgroup{background-color:#fdfdfd}.mw-parser-output .navbox-list{line-height:1.5em;border-color:#fdfdfd}.mw-parser-output .navbox-list-with-group{text-align:left;border-left-width:2px;border-left-style:solid}.mw-parser-output tr+tr>.navbox-abovebelow,.mw-parser-output tr+tr>.navbox-group,.mw-parser-output tr+tr>.navbox-image,.mw-parser-output tr+tr>.navbox-list{border-top:2px solid #fdfdfd}.mw-parser-output .navbox-title{background-color:#ccf}.mw-parser-output .navbox-abovebelow,.mw-parser-output .navbox-group,.mw-parser-output .navbox-subgroup .navbox-title{background-color:#ddf}.mw-parser-output .navbox-subgroup .navbox-group,.mw-parser-output .navbox-subgroup .navbox-abovebelow{background-color:#e6e6ff}.mw-parser-output .navbox-even{background-color:#f7f7f7}.mw-parser-output .navbox-odd{background-color:transparent}.mw-parser-output .navbox .hlist td dl,.mw-parser-output .navbox .hlist td ol,.mw-parser-output .navbox .hlist td ul,.mw-parser-output .navbox td.hlist dl,.mw-parser-output .navbox td.hlist ol,.mw-parser-output .navbox td.hlist ul{padding:0.125em 0}.mw-parser-output .navbox .navbar{display:block;font-size:100%}.mw-parser-output .navbox-title .navbar{float:left;text-align:left;margin-right:0.5em}</style></div><div role="navigation" class="navbox" aria-labelledby="Star_Trek" style="padding:3px"><table class="nowraplinks hlist mw-collapsible autocollapse navbox-inner" style="border-spacing:0;background:transparent;color:inherit"><tbody><tr><th scope="col" class="navbox-title" colspan="3"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1129693374"><style data-mw-deduplicate="TemplateStyles:r1063604349">.mw-parser-output .navbar{display:inline;font-size:88%;font-weight:normal}.mw-parser-output .navbar-collapse{float:left;text-align:left}.mw-parser-output .navbar-boxtext{word-spacing:0}.mw-parser-output .navbar ul{display:inline-block;white-space:nowrap;line-height:inherit}.mw-parser-output .navbar-brackets::before{margin-right:-0.125em;content:"[ "}.mw-parser-output .navbar-brackets::after{margin-left:-0.125em;content:" ]"}.mw-parser-output .navbar li{word-spacing:-0.125em}.mw-parser-output .navbar a>span,.mw-parser-output .navbar a>abbr{text-decoration:inherit}.mw-parser-output .navbar-mini abbr{font-variant:small-caps;border-bottom:none;text-decoration:none;cursor:inherit}.mw-parser-output .navbar-ct-full{font-size:114%;margin:0 7em}.mw-parser-output .navbar-ct-mini{font-size:114%;margin:0 4em}</style><div class="navbar plainlinks hlist navbar-mini"><ul><li class="nv-view"><a href="/wiki/Template:Star_Trek" title="Template:Star Trek"><abbr title="View this template" style=";;background:none transparent;border:none;box-shadow:none;padding:0;">v</abbr></a></li><li class="nv-talk"><a href="/wiki/Template_talk:Star_Trek" title="Template talk:Star Trek"><abbr title="Discuss this template" style=";;background:none transparent;border:none;box-shadow:none;padding:0;">t</abbr></a></li><li class="nv-edit"><a href="/wiki/Special:EditPage/Template:Star_Trek" title="Special:EditPage/Template:Star Trek"><abbr title="Edit this template" style=";;background:none transparent;border:none;box-shadow:none;padding:0;">e</abbr></a></li></ul></div><div id="Star_Trek" style="font-size:114%;margin:0 4em"><i><a href="/wiki/Star_Trek" title="Star Trek">Star Trek</a></i></div></th></tr><tr><td class="navbox-abovebelow" colspan="3"><div>
+<ul><li><a href="/wiki/Outline_of_Star_Trek" title="Outline of Star Trek">Outline</a></li>
+<li><a href="/wiki/Timeline_of_Star_Trek" title="Timeline of Star Trek">Timeline</a></li>
+<li><a href="/wiki/Star_Trek_canon" title="Star Trek canon">Canon</a></li>
+<li><a href="/wiki/List_of_Star_Trek_lists" title="List of Star Trek lists">Lists</a></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/List_of_Star_Trek_television_series" title="List of Star Trek television series">Television series</a> <br /> (<a href="/wiki/Lists_of_Star_Trek_episodes" title="Lists of Star Trek episodes">episodes</a>)</th><td class="navbox-list-with-group navbox-list navbox-odd hlist" style="width:100%;padding:0"><div style="padding:0 0.25em"></div><table class="nowraplinks navbox-subgroup" style="border-spacing:0"><tbody><tr><th scope="row" class="navbox-group" style="width:1%">Live-action</th><td class="navbox-list-with-group navbox-list navbox-odd" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><i><a href="/wiki/Star_Trek:_The_Original_Series" title="Star Trek: The Original Series">The Original Series</a></i>
+<ul><li><a href="/wiki/List_of_Star_Trek:_The_Original_Series_episodes" title="List of Star Trek: The Original Series episodes">episodes</a></li></ul></li>
+<li><i><a href="/wiki/Star_Trek:_The_Next_Generation" title="Star Trek: The Next Generation">The Next Generation</a></i>
+<ul><li><a href="/wiki/List_of_Star_Trek:_The_Next_Generation_episodes" title="List of Star Trek: The Next Generation episodes">episodes</a></li></ul></li>
+<li><i><a href="/wiki/Star_Trek:_Deep_Space_Nine" title="Star Trek: Deep Space Nine">Deep Space Nine</a></i>
+<ul><li><a href="/wiki/List_of_Star_Trek:_Deep_Space_Nine_episodes" title="List of Star Trek: Deep Space Nine episodes">episodes</a></li></ul></li>
+<li><i><a href="/wiki/Star_Trek:_Voyager" title="Star Trek: Voyager">Voyager</a></i>
+<ul><li><a href="/wiki/List_of_Star_Trek:_Voyager_episodes" title="List of Star Trek: Voyager episodes">episodes</a></li></ul></li>
+<li><i><a href="/wiki/Star_Trek:_Enterprise" title="Star Trek: Enterprise">Enterprise</a></i>
+<ul><li><a href="/wiki/List_of_Star_Trek:_Enterprise_episodes" title="List of Star Trek: Enterprise episodes">episodes</a></li></ul></li>
+<li><i><a href="/wiki/Star_Trek:_Discovery" title="Star Trek: Discovery">Discovery</a></i>
+<ul><li><a href="/wiki/List_of_Star_Trek:_Discovery_episodes" title="List of Star Trek: Discovery episodes">episodes</a></li></ul></li>
+<li><i><a href="/wiki/Star_Trek:_Picard" title="Star Trek: Picard">Picard</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_Strange_New_Worlds" title="Star Trek: Strange New Worlds">Strange New Worlds</a></i></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%">Animated</th><td class="navbox-list-with-group navbox-list navbox-even" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><i><a href="/wiki/Star_Trek:_The_Animated_Series" title="Star Trek: The Animated Series">The Animated Series</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_Lower_Decks" title="Star Trek: Lower Decks">Lower Decks</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_Prodigy" title="Star Trek: Prodigy">Prodigy</a></i></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%">Shorts</th><td class="navbox-list-with-group navbox-list navbox-odd" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><i><a href="/wiki/Star_Trek:_Short_Treks" title="Star Trek: Short Treks">Short Treks</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_Very_Short_Treks" title="Star Trek: Very Short Treks">Very Short Treks</a></i></li></ul>
+</div></td></tr></tbody></table><div></div></td><td class="noviewer navbox-image" rowspan="9" style="width:1px;padding:0 0 0 2px"><div><span typeof="mw:File"><a href="/wiki/File:Delta-shield.svg" class="mw-file-description" title="Star Trek logo"><img alt="Star Trek logo" src="//upload.wikimedia.org/wikipedia/commons/thumb/9/90/Delta-shield.svg/50px-Delta-shield.svg.png" decoding="async" width="50" height="81" class="mw-file-element" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/9/90/Delta-shield.svg/75px-Delta-shield.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/9/90/Delta-shield.svg/100px-Delta-shield.svg.png 2x" data-file-width="100" data-file-height="162" /></a></span><br /></div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/List_of_Star_Trek_films" title="List of Star Trek films">Feature films</a></th><td class="navbox-list-with-group navbox-list navbox-odd hlist" style="width:100%;padding:0"><div style="padding:0 0.25em"></div><table class="nowraplinks navbox-subgroup" style="border-spacing:0"><tbody><tr><th scope="row" class="navbox-group" style="width:1%"><i>The Original Series</i></th><td class="navbox-list-with-group navbox-list navbox-even" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><i><a href="/wiki/Star_Trek:_The_Motion_Picture" title="Star Trek: The Motion Picture">The Motion Picture</a></i></li>
+<li><i><a href="/wiki/Star_Trek_II:_The_Wrath_of_Khan" title="Star Trek II: The Wrath of Khan">The Wrath of Khan</a></i></li>
+<li><i><a href="/wiki/Star_Trek_III:_The_Search_for_Spock" title="Star Trek III: The Search for Spock">The Search for Spock</a></i></li>
+<li><i><a href="/wiki/Star_Trek_IV:_The_Voyage_Home" title="Star Trek IV: The Voyage Home">The Voyage Home</a></i></li>
+<li><i><a href="/wiki/Star_Trek_V:_The_Final_Frontier" title="Star Trek V: The Final Frontier">The Final Frontier</a></i></li>
+<li><i><a href="/wiki/Star_Trek_VI:_The_Undiscovered_Country" title="Star Trek VI: The Undiscovered Country">The Undiscovered Country</a></i></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%"><i>The Next Generation</i></th><td class="navbox-list-with-group navbox-list navbox-odd" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><i><a href="/wiki/Star_Trek_Generations" title="Star Trek Generations">Generations</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_First_Contact" title="Star Trek: First Contact">First Contact</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_Insurrection" title="Star Trek: Insurrection">Insurrection</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_Nemesis" title="Star Trek: Nemesis">Nemesis</a></i></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%">Reboot (<i>Kelvin Timeline</i>)</th><td class="navbox-list-with-group navbox-list navbox-even" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><i><a href="/wiki/Star_Trek_(film)" title="Star Trek (film)">Star Trek</a></i></li>
+<li><i><a href="/wiki/Star_Trek_Into_Darkness" title="Star Trek Into Darkness">Into Darkness</a></i></li>
+<li><i><a href="/wiki/Star_Trek_Beyond" title="Star Trek Beyond">Beyond</a></i></li></ul>
+</div></td></tr></tbody></table><div></div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%">Setting</th><td class="navbox-list-with-group navbox-list navbox-odd hlist" style="width:100%;padding:0"><div style="padding:0 0.25em"></div><table class="nowraplinks navbox-subgroup" style="border-spacing:0"><tbody><tr><th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/List_of_Star_Trek_characters" title="List of Star Trek characters">Characters</a></th><td class="navbox-list-with-group navbox-list navbox-odd" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><ul><li><a href="/wiki/List_of_Star_Trek_characters_(A%E2%80%93F)" title="List of Star Trek characters (A–F)">A–F</a></li>
+<li><a href="/wiki/List_of_Star_Trek_characters_(G%E2%80%93M)" title="List of Star Trek characters (G–M)">G–M</a></li>
+<li><a href="/wiki/List_of_Star_Trek_characters_(N%E2%80%93S)" title="List of Star Trek characters (N–S)">N–S</a></li>
+<li><a href="/wiki/List_of_Star_Trek_characters_(T%E2%80%93Z)" title="List of Star Trek characters (T–Z)">T–Z</a></li></ul></li>
+<li><a href="/wiki/Star_Trek_crossovers" title="Star Trek crossovers">Crossovers</a></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%">Concepts</th><td class="navbox-list-with-group navbox-list navbox-even" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><a href="/wiki/List_of_games_in_Star_Trek" title="List of games in Star Trek">Games</a></li>
+<li><i><a href="/wiki/Kobayashi_Maru" title="Kobayashi Maru">Kobayashi Maru</a></i></li>
+<li><a href="/wiki/Law_in_Star_Trek" title="Law in Star Trek">Law</a>
+<ul><li><a href="/wiki/Prime_Directive" title="Prime Directive">Prime Directive</a></li></ul></li>
+<li><a href="/wiki/List_of_Star_Trek_materials" title="List of Star Trek materials">Materials</a>
+<ul><li><a href="/wiki/Dilithium_(Star_Trek)" title="Dilithium (Star Trek)">Dilithium</a></li></ul></li>
+<li><a href="/wiki/Sexuality_in_Star_Trek" title="Sexuality in Star Trek">Sexuality</a></li>
+<li><a href="/wiki/Stardate" title="Stardate">Stardate</a></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/List_of_Star_Trek_regions_of_space" title="List of Star Trek regions of space">Locations</a></th><td class="navbox-list-with-group navbox-list navbox-odd" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><a href="/wiki/Class_M_planet" title="Class M planet">Class M planet</a></li>
+<li><a href="/wiki/Galactic_quadrant_(Star_Trek)" class="mw-redirect" title="Galactic quadrant (Star Trek)">Galactic quadrant</a></li>
+<li><a href="/wiki/Mirror_Universe" title="Mirror Universe">Mirror Universe</a></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/List_of_Star_Trek_aliens" title="List of Star Trek aliens">Cultures<br />and species</a></th><td class="navbox-list-with-group navbox-list navbox-even" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><a href="/wiki/Andorian" title="Andorian">Andorian</a></li>
+<li><a href="/wiki/Bajoran" title="Bajoran">Bajoran</a></li>
+<li><a href="/wiki/Borg" title="Borg">Borg</a></li>
+<li><a href="/wiki/Breen_(Star_Trek)" title="Breen (Star Trek)">Breen</a></li>
+<li><a href="/wiki/Cardassian" title="Cardassian">Cardassian</a></li>
+<li><a href="/wiki/Dominion_(Star_Trek)" title="Dominion (Star Trek)">Dominion</a></li>
+<li><a href="/wiki/Ferengi" title="Ferengi">Ferengi</a>
+<ul><li><a href="/wiki/Rules_of_Acquisition" title="Rules of Acquisition">Rules of Acquisition</a></li></ul></li>
+<li><a href="/wiki/Gorn" title="Gorn">Gorn</a></li>
+<li><a href="/wiki/Kazon" title="Kazon">Kazon</a></li>
+<li><a href="/wiki/Klingon" title="Klingon">Klingon</a>
+<ul><li><a href="/wiki/Klingon_High_Council" title="Klingon High Council">High Council</a></li>
+<li><a href="/wiki/Klingon_culture" title="Klingon culture">culture</a></li>
+<li><a href="/wiki/Klingon_language" title="Klingon language">language</a></li>
+<li><a href="/wiki/Klingon_grammar" title="Klingon grammar">grammar</a></li></ul></li>
+<li><a href="/wiki/Maquis_(Star_Trek)" title="Maquis (Star Trek)">Maquis</a></li>
+<li><a href="/wiki/Orion_(Star_Trek)" title="Orion (Star Trek)">Orion</a></li>
+<li><a href="/wiki/Q_(Star_Trek)" title="Q (Star Trek)">Q</a></li>
+<li><a href="/wiki/Romulan" title="Romulan">Romulan</a></li>
+<li><a href="/wiki/Species_8472" title="Species 8472">Species 8472</a></li>
+<li><a href="/wiki/United_Federation_of_Planets" title="United Federation of Planets">United Federation of Planets</a>
+<ul><li><a class="mw-selflink selflink">Starfleet</a></li>
+<li><a href="/wiki/Starfleet_Academy" title="Starfleet Academy">Academy</a></li>
+<li><a href="/wiki/Section_31_(Star_Trek)" title="Section 31 (Star Trek)">Section 31</a></li></ul></li>
+<li><a href="/wiki/Tribble" title="Tribble">Tribble</a></li>
+<li><a href="/wiki/Vidiians" title="Vidiians">Vidiians</a></li>
+<li><a href="/wiki/Vulcan_(Star_Trek)" title="Vulcan (Star Trek)">Vulcan</a>
+<ul><li><a href="/wiki/Vulcan_nerve_pinch" title="Vulcan nerve pinch">nerve pinch</a></li>
+<li><a href="/wiki/Vulcan_salute" title="Vulcan salute">salute</a></li></ul></li>
+<li><a href="/wiki/Xindi_(Star_Trek)" class="mw-redirect" title="Xindi (Star Trek)">Xindi</a></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/Technology_in_Star_Trek" title="Technology in Star Trek">Technology</a></th><td class="navbox-list-with-group navbox-list navbox-odd" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><a href="/wiki/Cloaking_device" title="Cloaking device">Cloaking device</a></li>
+<li><a href="/wiki/Communicator_(Star_Trek)" title="Communicator (Star Trek)">Communicator</a></li>
+<li><a href="/wiki/Shields_(Star_Trek)" title="Shields (Star Trek)">Deflector shields</a></li>
+<li><a href="/wiki/Holodeck" title="Holodeck">Holodeck</a></li>
+<li><a href="/wiki/Hypospray" title="Hypospray">Hypospray</a></li>
+<li><a href="/wiki/Impulse_drive" class="mw-redirect" title="Impulse drive">Impulse drive</a></li>
+<li><a href="/wiki/Jefferies_tube" class="mw-redirect" title="Jefferies tube">Jefferies tube</a></li>
+<li><a href="/wiki/LCARS" title="LCARS">LCARS</a></li>
+<li><a href="/wiki/Medicine_in_Star_Trek" title="Medicine in Star Trek">Medicine</a></li>
+<li><a href="/wiki/Replicator_(Star_Trek)" title="Replicator (Star Trek)">Replicator</a></li>
+<li><a href="/wiki/Spacecraft_in_Star_Trek" title="Spacecraft in Star Trek">Spacecraft</a>
+<ul><li><a href="/wiki/Deep_Space_Nine_(fictional_space_station)" title="Deep Space Nine (fictional space station)">Deep Space Nine</a></li>
+<li><a href="/wiki/USS_Defiant" title="USS Defiant"><i>Defiant</i></a></li>
+<li><a href="/wiki/Earth_Spacedock" title="Earth Spacedock">Earth Spacedock</a></li>
+<li><a href="/wiki/Starship_Enterprise" title="Starship Enterprise"><i>Enterprise</i></a>
+<ul><li><a href="/wiki/Enterprise_(NX-01)" title="Enterprise (NX-01)">NX-01</a></li>
+<li><a href="/wiki/USS_Enterprise_(NCC-1701)" title="USS Enterprise (NCC-1701)">NCC-1701</a></li>
+<li><a href="/wiki/USS_Enterprise_(NCC-1701-A)" title="USS Enterprise (NCC-1701-A)">A</a></li>
+<li><a href="/wiki/USS_Enterprise_(NCC-1701-D)" title="USS Enterprise (NCC-1701-D)">D</a></li>
+<li><a href="/wiki/USS_Enterprise_(NCC-1701-E)" title="USS Enterprise (NCC-1701-E)">E</a></li></ul></li>
+<li><a href="/wiki/Klingon_starships" title="Klingon starships">Klingon starships</a></li>
+<li><a href="/wiki/Shuttlecraft_(Star_Trek)" title="Shuttlecraft (Star Trek)">Shuttlecraft</a></li>
+<li><a href="/wiki/USS_Voyager_(Star_Trek)" title="USS Voyager (Star Trek)"><i>Voyager</i></a></li></ul></li>
+<li><a href="/wiki/Transporter_(Star_Trek)" title="Transporter (Star Trek)">Transporter</a></li>
+<li><a href="/wiki/Tricorder" title="Tricorder">Tricorder</a></li>
+<li><a href="/wiki/Star_Trek_uniforms" title="Star Trek uniforms">Uniforms</a></li>
+<li><a href="/wiki/Warp_drive" title="Warp drive">Warp drive</a></li>
+<li><a href="/wiki/Weapons_in_Star_Trek" title="Weapons in Star Trek">Weapons</a>
+<ul><li><a href="/wiki/Bat%27leth" title="Bat&#39;leth">Bat'leth</a></li></ul></li></ul>
+</div></td></tr></tbody></table><div></div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%">Production</th><td class="navbox-list-with-group navbox-list navbox-even hlist" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><a href="/wiki/List_of_Star_Trek_production_staff" title="List of Star Trek production staff">List of staff</a></li>
+<li><a href="/wiki/Gene_Roddenberry" title="Gene Roddenberry">Gene Roddenberry</a></li>
+<li><a href="/wiki/Norway_Corporation" title="Norway Corporation">Norway Corporation</a></li>
+<li><a href="/wiki/List_of_Star_Trek_composers_and_music" title="List of Star Trek composers and music">Composers and music</a>
+<ul><li><a href="/wiki/Theme_from_Star_Trek" title="Theme from Star Trek">musical theme</a></li></ul></li>
+<li>"<a href="/wiki/Where_no_man_has_gone_before" title="Where no man has gone before">Where no man has gone before</a>"</li>
+<li>"<a href="/wiki/Beam_me_up,_Scotty" title="Beam me up, Scotty">Beam me up, Scotty</a>"</li>
+<li><a href="/wiki/Redshirt_(stock_character)" title="Redshirt (stock character)">Redshirt</a></li>
+<li><a href="/wiki/List_of_accolades_received_by_Star_Trek_(film_franchise)" title="List of accolades received by Star Trek (film franchise)">Accolades (film franchise)</a></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%">Unmade projects</th><td class="navbox-list-with-group navbox-list navbox-odd hlist" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><i><a href="/wiki/Star_Trek:_The_God_Thing" title="Star Trek: The God Thing">The God Thing</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_Planet_of_the_Titans" title="Star Trek: Planet of the Titans">Planet of the Titans</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_Phase_II" title="Star Trek: Phase II">Phase II</a></i></li>
+<li><i><a href="/wiki/Development_of_Star_Trek_4" title="Development of Star Trek 4">Star Trek 4</a></i></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/Star_Trek_spin-off_fiction" title="Star Trek spin-off fiction">Spin-off fiction</a></th><td class="navbox-list-with-group navbox-list navbox-even hlist" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><a href="/wiki/List_of_Star_Trek_games" title="List of Star Trek games">Games</a></li>
+<li><a href="/wiki/Star_Trek_(comics)" title="Star Trek (comics)">Comics</a></li>
+<li><a href="/wiki/List_of_Star_Trek_novels" title="List of Star Trek novels">Novels</a></li>
+<li><a href="/wiki/List_of_Star_Trek_tie-in_fiction" title="List of Star Trek tie-in fiction">Reference books</a></li>
+<li>Stage
+<ul><li><i><a href="/wiki/A_Klingon_Christmas_Carol" title="A Klingon Christmas Carol">A Klingon Christmas Carol</a></i></li>
+<li><a href="/wiki/%CA%BCu%CA%BC" title="ʼuʼ">Klingon opera</a></li></ul></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%">Aftershows</th><td class="navbox-list-with-group navbox-list navbox-odd hlist" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><i><a href="/wiki/After_Trek" title="After Trek">After Trek</a></i></li>
+<li><i><a href="/wiki/The_Ready_Room" title="The Ready Room">The Ready Room</a></i></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%">Documentaries</th><td class="navbox-list-with-group navbox-list navbox-even hlist" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><i><a href="/wiki/Trekkies_(film)" title="Trekkies (film)">Trekkies</a></i></li>
+<li><i><a href="/wiki/Mind_Meld" title="Mind Meld">Mind Meld</a></i></li>
+<li><i><a href="/wiki/Trekkies_2" title="Trekkies 2">Trekkies 2</a></i></li>
+<li><i><a href="/wiki/How_William_Shatner_Changed_the_World" title="How William Shatner Changed the World">How William Shatner Changed the World</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_Beyond_the_Final_Frontier" title="Star Trek: Beyond the Final Frontier">Beyond the Final Frontier</a></i></li>
+<li><i><a href="/wiki/The_Captains_(film)" title="The Captains (film)">The Captains</a></i></li>
+<li><i><a href="/wiki/Trek_Nation" title="Trek Nation">Trek Nation</a></i></li>
+<li><i><a href="/wiki/For_the_Love_of_Spock" title="For the Love of Spock">For the Love of Spock</a></i></li>
+<li><i><a href="/wiki/Star_Trek:_Deep_Space_Nine#What_We_Left_Behind" title="Star Trek: Deep Space Nine">What We Left Behind</a></i></li></ul>
+</div></td></tr><tr><th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/Cultural_influence_of_Star_Trek" title="Cultural influence of Star Trek">Cultural influence</a></th><td class="navbox-list-with-group navbox-list navbox-odd hlist" style="width:100%;padding:0"><div style="padding:0 0.25em">
+<ul><li><a href="/wiki/Kirk_and_Uhura%27s_kiss" title="Kirk and Uhura&#39;s kiss">Kirk and Uhura's kiss</a></li>
+<li><a href="/wiki/Comparison_of_Star_Trek_and_Star_Wars" title="Comparison of Star Trek and Star Wars">Comparison to <i>Star Wars</i></a></li>
+<li><a href="/wiki/Trekkie" title="Trekkie">Fandom</a>
+<ul><li><a href="/wiki/Star_Trek_fan_productions" title="Star Trek fan productions">productions</a></li></ul></li>
+<li><a href="/wiki/Kirk/Spock" title="Kirk/Spock">Kirk/Spock</a></li>
+<li><a href="/wiki/Memory_Alpha" title="Memory Alpha">Memory Alpha</a></li>
+<li><a href="/wiki/Shakespeare_and_Star_Trek" title="Shakespeare and Star Trek">Shakespeare and <i>Star Trek</i></a></li>
+<li><a href="/wiki/Star_Trek:_The_Exhibition" title="Star Trek: The Exhibition">The Exhibition</a></li>
+<li><a href="/wiki/Star_Trek:_The_Experience" title="Star Trek: The Experience">The Experience</a></li>
+<li>"<a href="/wiki/The_Last_Voyage_of_the_Starship_Enterprise" title="The Last Voyage of the Starship Enterprise">The Last Voyage of the Starship <i>Enterprise</i></a>" (1976 <i>SNL</i> sketch)</li>
+<li><i><a href="/wiki/Free_Enterprise_(film)" title="Free Enterprise (film)">Free Enterprise</a></i> (1999 film)</li>
+<li><i><a href="/wiki/Galaxy_Quest" title="Galaxy Quest">Galaxy Quest</a></i> (1999 film)</li>
+<li>"<a href="/wiki/Where_No_Fan_Has_Gone_Before" title="Where No Fan Has Gone Before">Where No Fan Has Gone Before</a>" (2002 <i>Futurama</i> episode)</li>
+<li><i><a href="/wiki/The_Orville" title="The Orville">The Orville</a></i> (2017 television series)</li>
+<li><i><a href="/wiki/Please_Stand_By" title="Please Stand By">Please Stand By</a></i> (2017 film)</li>
+<li>"<a href="/wiki/USS_Callister" title="USS Callister">USS Callister</a>" (2017 <i>Black Mirror</i> episode)</li></ul>
+</div></td></tr><tr><td class="navbox-abovebelow" colspan="3"><div>
+<ul><li><b><a href="/wiki/Category:Star_Trek" title="Category:Star Trek">Category</a></b></li></ul>
+</div></td></tr></tbody></table></div>
+<style data-mw-deduplicate="TemplateStyles:r1130092004">.mw-parser-output .portal-bar{font-size:88%;font-weight:bold;display:flex;justify-content:center;align-items:baseline}.mw-parser-output .portal-bar-bordered{padding:0 2em;background-color:#fdfdfd;border:1px solid #a2a9b1;clear:both;margin:1em auto 0}.mw-parser-output .portal-bar-related{font-size:100%;justify-content:flex-start}.mw-parser-output .portal-bar-unbordered{padding:0 1.7em;margin-left:0}.mw-parser-output .portal-bar-header{margin:0 1em 0 0.5em;flex:0 0 auto;min-height:24px}.mw-parser-output .portal-bar-content{display:flex;flex-flow:row wrap;flex:0 1 auto;padding:0.15em 0;column-gap:1em;align-items:baseline;margin:0;list-style:none}.mw-parser-output .portal-bar-content-related{margin:0;list-style:none}.mw-parser-output .portal-bar-item{display:inline-block;margin:0.15em 0.2em;min-height:24px;line-height:24px}@media screen and (max-width:768px){.mw-parser-output .portal-bar{font-size:88%;font-weight:bold;display:flex;flex-flow:column wrap;align-items:baseline}.mw-parser-output .portal-bar-header{text-align:center;flex:0;padding-left:0.5em;margin:0 auto}.mw-parser-output .portal-bar-related{font-size:100%;align-items:flex-start}.mw-parser-output .portal-bar-content{display:flex;flex-flow:row wrap;align-items:center;flex:0;column-gap:1em;border-top:1px solid #a2a9b1;margin:0 auto;list-style:none}.mw-parser-output .portal-bar-content-related{border-top:none;margin:0;list-style:none}}.mw-parser-output .navbox+link+.portal-bar,.mw-parser-output .navbox+style+.portal-bar,.mw-parser-output .navbox+link+.portal-bar-bordered,.mw-parser-output .navbox+style+.portal-bar-bordered,.mw-parser-output .sister-bar+link+.portal-bar,.mw-parser-output .sister-bar+style+.portal-bar,.mw-parser-output .portal-bar+.navbox-styles+.navbox,.mw-parser-output .portal-bar+.navbox-styles+.sister-bar{margin-top:-1px}</style><div class="portal-bar noprint metadata noviewer portal-bar-bordered" role="navigation" aria-label="Portals"><span class="portal-bar-header"><a href="/wiki/Wikipedia:Contents/Portals" title="Wikipedia:Contents/Portals">Portals</a>:</span><ul class="portal-bar-content"><li class="portal-bar-item"><span typeof="mw:File"><a href="/wiki/File:Dragon-149393.svg" class="mw-file-description"><img alt="icon" src="//upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Dragon-149393.svg/18px-Dragon-149393.svg.png" decoding="async" width="18" height="19" class="mw-file-element" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Dragon-149393.svg/28px-Dragon-149393.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Dragon-149393.svg/37px-Dragon-149393.svg.png 2x" data-file-width="512" data-file-height="529" /></a></span>&#160;<a href="/wiki/Portal:Speculative_fiction" title="Portal:Speculative fiction">Speculative fiction</a></li><li class="portal-bar-item"><span typeof="mw:File"><a href="/wiki/File:Blank_television_set.svg" class="mw-file-description"><img alt="icon" src="//upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Blank_television_set.svg/21px-Blank_television_set.svg.png" decoding="async" width="21" height="14" class="mw-file-element" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Blank_television_set.svg/32px-Blank_television_set.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Blank_television_set.svg/42px-Blank_television_set.svg.png 2x" data-file-width="138" data-file-height="92" /></a></span>&#160;<a href="/wiki/Portal:Television" title="Portal:Television">Television</a></li></ul></div>
+<!-- 
+NewPP limit report
+Parsed by mw2380
+Cached time: 20231120050727
+Cache expiry: 1814400
+Reduced expiry: false
+Complications: [vary‐revision‐sha1, show‐toc]
+CPU time usage: 0.323 seconds
+Real time usage: 0.411 seconds
+Preprocessor visited node count: 1941/1000000
+Post‐expand include size: 75614/2097152 bytes
+Template argument size: 1875/2097152 bytes
+Highest expansion depth: 9/100
+Expensive parser function count: 6/500
+Unstrip recursion depth: 1/20
+Unstrip post‐expand size: 39184/5000000 bytes
+Lua time usage: 0.190/10.000 seconds
+Lua memory usage: 5843580/52428800 bytes
+Number of Wikibase entities loaded: 0/400
+-->
+<!--
+Transclusion expansion time report (%,ms,calls,template)
+100.00%  334.895      1 -total
+ 32.15%  107.675      1 Template:Reflist
+ 22.23%   74.463      4 Template:Navbox
+ 21.47%   71.903      1 Template:Star_Trek
+ 19.06%   63.845      2 Template:Cite_book
+ 11.49%   38.491      1 Template:Infobox_military_unit
+ 11.47%   38.422      1 Template:About
+  9.16%   30.667      2 Template:Short_description
+  8.60%   28.806      1 Template:Infobox
+  7.48%   25.040      1 Template:Portal_bar
+-->
+
+<!-- Saved in parser cache with key enwiki:pcache:idhash:29340-0!thumbsize=2 and timestamp 20231120050727 and revision id 1182208104. Rendering was triggered because: page-view
+ -->
+</div><!--esi <esi:include src="/esitest-fa8a495983347898/content" /> -->
+<div class="printfooter" data-nosnippet="">Retrieved from "<a dir="ltr" href="https://en.wikipedia.org/w/index.php?title=Starfleet&amp;oldid=1182208104">https://en.wikipedia.org/w/index.php?title=Starfleet&amp;oldid=1182208104</a>"</div></div>
+					<div id="catlinks" class="catlinks" data-mw="interface"><div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Help:Category" title="Help:Category">Categories</a>: <ul><li><a href="/wiki/Category:Fictional_elements_introduced_in_1966" title="Category:Fictional elements introduced in 1966">Fictional elements introduced in 1966</a></li><li><a href="/wiki/Category:Star_Trek_organizations" title="Category:Star Trek organizations">Star Trek organizations</a></li><li><a href="/wiki/Category:Space_navies" title="Category:Space navies">Space navies</a></li></ul></div><div id="mw-hidden-catlinks" class="mw-hidden-catlinks mw-hidden-cats-hidden">Hidden categories: <ul><li><a href="/wiki/Category:Articles_with_short_description" title="Category:Articles with short description">Articles with short description</a></li><li><a href="/wiki/Category:Short_description_matches_Wikidata" title="Category:Short description matches Wikidata">Short description matches Wikidata</a></li><li><a href="/wiki/Category:Short_description_is_different_from_Wikidata" title="Category:Short description is different from Wikidata">Short description is different from Wikidata</a></li></ul></div></div>
+				</div>
+			</main>
+			
+		</div>
+		<div class="mw-footer-container">
+			
+<footer id="footer" class="mw-footer" role="contentinfo" >
+	<ul id="footer-info">
+	<li id="footer-info-lastmod"> This page was last edited on 2023-10-27, at 13:41:21<span class="anonymous-show">&#160;(UTC)</span>.</li>
+	<li id="footer-info-copyright">Text is available under the <a rel="license" href="//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License">Creative Commons Attribution-ShareAlike License 4.0</a><a rel="license" href="//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License" style="display:none;"></a>;
+additional terms may apply.  By using this site, you agree to the <a href="//foundation.wikimedia.org/wiki/Terms_of_Use">Terms of Use</a> and <a href="//foundation.wikimedia.org/wiki/Privacy_policy">Privacy Policy</a>. Wikipedia® is a registered trademark of the <a href="//www.wikimediafoundation.org/">Wikimedia Foundation, Inc.</a>, a non-profit organization.</li>
+</ul>
+
+	<ul id="footer-places">
+	<li id="footer-places-privacy"><a href="https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Privacy_policy">Privacy policy</a></li>
+	<li id="footer-places-about"><a href="/wiki/Wikipedia:About">About Wikipedia</a></li>
+	<li id="footer-places-disclaimers"><a href="/wiki/Wikipedia:General_disclaimer">Disclaimers</a></li>
+	<li id="footer-places-contact"><a href="//en.wikipedia.org/wiki/Wikipedia:Contact_us">Contact Wikipedia</a></li>
+	<li id="footer-places-wm-codeofconduct"><a href="https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Universal_Code_of_Conduct">Code of Conduct</a></li>
+	<li id="footer-places-developers"><a href="https://developer.wikimedia.org">Developers</a></li>
+	<li id="footer-places-statslink"><a href="https://stats.wikimedia.org/#/en.wikipedia.org">Statistics</a></li>
+	<li id="footer-places-cookiestatement"><a href="https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Cookie_statement">Cookie statement</a></li>
+	<li id="footer-places-mobileview"><a href="//en.m.wikipedia.org/w/index.php?title=Starfleet&amp;mobileaction=toggle_view_mobile" class="noprint stopMobileRedirectToggle">Mobile view</a></li>
+</ul>
+
+	<ul id="footer-icons" class="noprint">
+	<li id="footer-copyrightico"><a href="https://wikimediafoundation.org/"><img src="/static/images/footer/wikimedia-button.png" srcset="/static/images/footer/wikimedia-button-1.5x.png 1.5x, /static/images/footer/wikimedia-button-2x.png 2x" width="88" height="31" alt="Wikimedia Foundation" loading="lazy" /></a></li>
+	<li id="footer-poweredbyico"><a href="https://www.mediawiki.org/"><img src="/static/images/footer/poweredby_mediawiki_88x31.png" alt="Powered by MediaWiki" srcset="/static/images/footer/poweredby_mediawiki_132x47.png 1.5x, /static/images/footer/poweredby_mediawiki_176x62.png 2x" width="88" height="31" loading="lazy"></a></li>
+</ul>
+
+</footer>
+
+		</div>
+	</div> 
+</div> 
+<div class="vector-header-container vector-sticky-header-container">
+	<div id="vector-sticky-header" class="vector-sticky-header">
+		<div class="vector-sticky-header-start">
+			<div class="vector-sticky-header-icon-start vector-button-flush-left vector-button-flush-right" aria-hidden="true">
+				<button class="cdx-button cdx-button--weight-quiet cdx-button--icon-only vector-sticky-header-search-toggle" id="" tabindex="-1" data-event-name="ui.vector-sticky-search-form.icon"><span class="vector-icon mw-ui-icon-search mw-ui-icon-wikimedia-search"></span>
+
+<span>Search</span>
+			</button>
+		</div>
+			
+		<div role="search" class="vector-search-box-vue  vector-search-box-show-thumbnail vector-search-box">
+			<div class="vector-typeahead-search-container">
+				<div class="cdx-typeahead-search cdx-typeahead-search--show-thumbnail">
+					<form action="/w/index.php" id="vector-sticky-search-form" class="cdx-search-input cdx-search-input--has-end-button">
+						<div  class="cdx-search-input__input-wrapper"  data-search-loc="header-moved">
+							<div class="cdx-text-input cdx-text-input--has-start-icon">
+								<input
+									class="cdx-text-input__input"
+									
+									type="search" name="search" placeholder="Search Wikipedia">
+								<span class="cdx-text-input__icon cdx-text-input__start-icon"></span>
+							</div>
+							<input type="hidden" name="title" value="Special:Search">
+						</div>
+						<button class="cdx-button cdx-search-input__end-button">Search</button>
+					</form>
+				</div>
+			</div>
+		</div>
+		<div class="vector-sticky-header-context-bar">
+				<nav role="navigation" aria-label="Contents" class="vector-toc-landmark">
+						
+					<div id="vector-sticky-header-toc" class="vector-dropdown mw-portlet mw-portlet-sticky-header-toc vector-sticky-header-toc vector-button-flush-left"  >
+						<input type="checkbox" id="vector-sticky-header-toc-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-sticky-header-toc" class="vector-dropdown-checkbox "  aria-label="Toggle the table of contents"  >
+						<label id="vector-sticky-header-toc-label" for="vector-sticky-header-toc-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-listBullet mw-ui-icon-wikimedia-listBullet"></span>
+
+<span class="vector-dropdown-label-text">Toggle the table of contents</span>
+						</label>
+						<div class="vector-dropdown-content">
+					
+						<div id="vector-sticky-header-toc-unpinned-container" class="vector-unpinned-container">
+						</div>
+					
+						</div>
+					</div>
+			</nav>
+				<div class="vector-sticky-header-context-bar-primary" aria-hidden="true" ><span class="mw-page-title-main">Starfleet</span></div>
+			</div>
+		</div>
+		<div class="vector-sticky-header-end" aria-hidden="true">
+			<div class="vector-sticky-header-icons">
+				<a href="#" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only" id="ca-talk-sticky-header" tabindex="-1" data-event-name="talk-sticky-header"><span class="vector-icon mw-ui-icon-speechBubbles mw-ui-icon-wikimedia-speechBubbles"></span>
+
+<span></span>
+			</a>
+			<a href="#" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only" id="ca-subject-sticky-header" tabindex="-1" data-event-name="subject-sticky-header"><span class="vector-icon mw-ui-icon-article mw-ui-icon-wikimedia-article"></span>
+
+<span></span>
+			</a>
+			<a href="#" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only" id="ca-history-sticky-header" tabindex="-1" data-event-name="history-sticky-header"><span class="vector-icon mw-ui-icon-wikimedia-history mw-ui-icon-wikimedia-wikimedia-history"></span>
+
+<span></span>
+			</a>
+			<a href="#" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only mw-watchlink" id="ca-watchstar-sticky-header" tabindex="-1" data-event-name="watch-sticky-header"><span class="vector-icon mw-ui-icon-wikimedia-star mw-ui-icon-wikimedia-wikimedia-star"></span>
+
+<span></span>
+			</a>
+			<a href="#" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only" id="ca-edit-sticky-header" tabindex="-1" data-event-name="wikitext-edit-sticky-header"><span class="vector-icon mw-ui-icon-wikimedia-wikiText mw-ui-icon-wikimedia-wikimedia-wikiText"></span>
+
+<span></span>
+			</a>
+			<a href="#" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only" id="ca-ve-edit-sticky-header" tabindex="-1" data-event-name="ve-edit-sticky-header"><span class="vector-icon mw-ui-icon-wikimedia-edit mw-ui-icon-wikimedia-wikimedia-edit"></span>
+
+<span></span>
+			</a>
+			<a href="#" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only" id="ca-viewsource-sticky-header" tabindex="-1" data-event-name="ve-edit-protected-sticky-header"><span class="vector-icon mw-ui-icon-wikimedia-editLock mw-ui-icon-wikimedia-wikimedia-editLock"></span>
+
+<span></span>
+			</a>
+		</div>
+			<div class="vector-sticky-header-buttons">
+				<button class="cdx-button cdx-button--weight-quiet mw-interlanguage-selector" id="p-lang-btn-sticky-header" tabindex="-1" data-event-name="ui.dropdown-p-lang-btn-sticky-header"><span class="vector-icon mw-ui-icon-wikimedia-language mw-ui-icon-wikimedia-wikimedia-language"></span>
+
+<span>33 languages</span>
+			</button>
+			<a href="#" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--action-progressive" id="ca-addsection-sticky-header" tabindex="-1" data-event-name="addsection-sticky-header"><span class="vector-icon mw-ui-icon-speechBubbleAdd-progressive mw-ui-icon-wikimedia-speechBubbleAdd-progressive"></span>
+
+<span>Add topic</span>
+			</a>
+		</div>
+			<div class="vector-sticky-header-icon-end">
+				<div class="vector-user-links">
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+<div class="vector-settings" id="p-dock-bottom">
+	<ul>
+		<li>
+		
+		<button class="cdx-button cdx-button--icon-only vector-limited-width-toggle" id=""><span class="vector-icon mw-ui-icon-fullScreen mw-ui-icon-wikimedia-fullScreen"></span>
+
+<span>Toggle limited content width</span>
+</button>
+</li>
+	</ul>
+</div>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgHostname":"mw2425","wgBackendResponseTime":178,"wgPageParseReport":{"limitreport":{"cputime":"0.323","walltime":"0.411","ppvisitednodes":{"value":1941,"limit":1000000},"postexpandincludesize":{"value":75614,"limit":2097152},"templateargumentsize":{"value":1875,"limit":2097152},"expansiondepth":{"value":9,"limit":100},"expensivefunctioncount":{"value":6,"limit":500},"unstrip-depth":{"value":1,"limit":20},"unstrip-size":{"value":39184,"limit":5000000},"entityaccesscount":{"value":0,"limit":400},"timingprofile":["100.00%  334.895      1 -total"," 32.15%  107.675      1 Template:Reflist"," 22.23%   74.463      4 Template:Navbox"," 21.47%   71.903      1 Template:Star_Trek"," 19.06%   63.845      2 Template:Cite_book"," 11.49%   38.491      1 Template:Infobox_military_unit"," 11.47%   38.422      1 Template:About","  9.16%   30.667      2 Template:Short_description","  8.60%   28.806      1 Template:Infobox","  7.48%   25.040      1 Template:Portal_bar"]},"scribunto":{"limitreport-timeusage":{"value":"0.190","limit":"10.000"},"limitreport-memusage":{"value":5843580,"limit":52428800}},"cachereport":{"origin":"mw2380","timestamp":"20231120050727","ttl":1814400,"transientcontent":false}}});});</script>
+<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"Article","name":"Starfleet","url":"https:\/\/en.wikipedia.org\/wiki\/Starfleet","sameAs":"http:\/\/www.wikidata.org\/entity\/Q718644","mainEntity":"http:\/\/www.wikidata.org\/entity\/Q718644","author":{"@type":"Organization","name":"Contributors to Wikimedia projects"},"publisher":{"@type":"Organization","name":"Wikimedia Foundation, Inc.","logo":{"@type":"ImageObject","url":"https:\/\/www.wikimedia.org\/static\/images\/wmf-hor-googpub.png"}},"datePublished":"2001-12-23T05:21:39Z","dateModified":"2023-10-27T20:41:21Z","headline":"fictional space flight organization"}</script>
+</body>
+</html>

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -2,7 +2,6 @@ genrule(
     name = "gen_verbose_clang_tidy",
     srcs = [],
     outs = ["verbose-clang-tidy.sh"],
-    # echo "$(dirname bazel-out/k8-fastbuild/bin/tools/verbose-clang-tidy.sh)/../<tidy-path>) ..."
     cmd = """
 echo "$$(dirname $@)/../$(rootpath {tidy}) --enable-check-profile \\$$@" > $@
 """.format(
@@ -16,4 +15,10 @@ sh_binary(
     name = "verbose-clang-tidy",
     srcs = ["verbose-clang-tidy.sh"],
     data = ["@llvm_toolchain//:clang-tidy"],
+)
+
+py_binary(
+    name = "deflate_compress",
+    srcs = ["deflate_compress.py"],
+    visibility = ["//:__subpackages__"],
 )

--- a/tools/compressed_file.bzl
+++ b/tools/compressed_file.bzl
@@ -1,0 +1,37 @@
+"""
+Compresses a DEFLATE compressed file with a fixed or dynamic Huffman tree.
+"""
+
+def compressed_file(
+        name,
+        src,
+        strategy = "fixed"):
+    """
+    Compresses a file with the DEFLATE algorithm and a fixed or dynamic Huffman tree.
+
+    Args:
+      name: string
+        Name for compressed_file rule.
+      src: string_label
+        Decompressed file.
+      strategy: string
+        one of [`fixed`, `dynamic`].
+
+        Determines if compression should use a fixed Huffman tree or a dynamic
+        Huffman tree.
+    """
+    if strategy not in ["fixed", "dynamic"]:
+        fail()
+
+    tools = ["//tools:deflate_compress"]
+
+    native.genrule(
+        name = "gen_" + name,
+        srcs = [src],
+        outs = [name],
+        tools = tools,
+        cmd = "$(execpath {tool}) --src $< {strat} > $@".format(
+            tool = tools[0],
+            strat = "--fixed" if strategy == "fixed" else "",
+        ),
+    )

--- a/tools/deflate_compress.py
+++ b/tools/deflate_compress.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+import zlib
+
+def main(args):
+    strategy = zlib.Z_FIXED if args.fixed else zlib.Z_DEFAULT_STRATEGY
+    compression = zlib.compressobj(
+        # negative means no header or trailing checksum.
+        # basically raw DEFLATE instead of zlib format.
+        wbits=-zlib.MAX_WBITS,
+        strategy=strategy)
+    with open(args.src, "rb") as src:
+        data = src.read()
+    compressed = compression.compress(data)
+    compressed += compression.flush()
+
+    sys.stdout.buffer.write(compressed)
+
+parser = argparse.ArgumentParser(
+    prog="deflate_compress",
+    description="generates deflate compressed data from a file",
+)
+
+parser.add_argument("--src", help="path to input file", required=True)
+parser.add_argument("--fixed", help="use fixed strategy", action="store_true")
+
+if __name__ == "__main__":
+    main(parser.parse_args())


### PR DESCRIPTION
test data for fixed and dynamic huffman trees

and a script to generate it

I guess the nice way to do this would be to bring in rules_python and
generate the data in a genrule, or pull in zlib and have our test
generate the compressed data at run-time. We can add that later if
we find keeping the compressed and decompressed data in sync is annoying
enough.

Change-Id: Iaba4043956a2eb6fd0f51aef40414ae948a7311e