### PR TITLE
Build before and after compile commands extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install the recommended extensions. See .vscode/extensions.json.
 Create a compilation database:
 
 ```sh
-bazel run @hedron_compile_commands//:refresh_all && bazel build //...
+bazel build //... && bazel run @hedron_compile_commands//:refresh_all && bazel build //...
 ```
 
 Then configure [clangd](https://clangd.llvm.org/).


### PR DESCRIPTION
Hey guys! Hedron Compile Commands Extractor author here. I saw your #111, @garymm, while catching up on https://github.com/hedronvision/bazel-compile-commands-extractor/issues/140. If you're going to run a build after, it might well be worth running it before, after. That way the extractor is more likely to hit a fresh header cache from the build and run faster :)