### PR TITLE
use clang for coverage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,10 +22,12 @@ build:verbose-clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=//tools:ver
 build:clang-tidy --config=clang-tidy-base
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_toolchain//:clang-tidy
 
-try-import %workspace%/user.bazelrc
-
 build --workspace_status_command=tools/bazel_workspace_status.sh
 # Do not load LD_LIBRARY_PATH from the environment. This leads to more cache hits
 # when triggering builds using different shells on the same machine.
 # https://stackoverflow.com/questions/74881594/bazel-builds-from-scratch-ignoring-cache
 build --incompatible_strict_action_env
+
+coverage --config=clang
+
+try-import %workspace%/user.bazelrc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,9 +62,8 @@ jobs:
     - run: |
         bazel \
           --bazelrc=.github/workflows/ci.bazelrc \
-          coverage \
-          --instrumentation_filter="-/:boost_ut" \
-          //...
+          run \
+          //tools:lcov_list
 
     - uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -9,15 +9,3 @@ build --remote_download_minimal
 
 test --test_output=all
 test --test_verbose_timeout_warnings
-
-coverage --combined_report=lcov
-coverage --strategy=CoverageReport=local
-# At least some of this is needed for the coverage tool to work.
-coverage --experimental_split_coverage_postprocessing
-coverage --experimental_fetch_all_coverage_outputs
-coverage --remote_download_outputs=all
-coverage --experimental_remote_download_regex=.*/((testlogs/.*/_coverage/.*)|coverage.dat$|_coverage/_coverage_report.dat$)
-# Not sure why it doesn't work with clang. Should be possible.
-coverage --extra_toolchains=//toolchain:gcc
-# Needed because our tests are in a different package than the code they test.
-coverage --instrumentation_filter='//.*'

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -223,3 +223,13 @@ http_archive(
 load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
 
 hedron_compile_commands_setup()
+
+http_archive(
+    name = "lcov",
+    build_file_content = """
+exports_files(glob(["**/*"]))
+""",
+    sha256 = "987031ad5528c8a746d4b52b380bc1bffe412de1f2b9c2ba5224995668e3240b",
+    strip_prefix = "lcov-1.16",
+    url = "https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16.tar.gz",
+)

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//tools:lcov.bzl", "lcov")
+
 genrule(
     name = "gen_verbose_clang_tidy",
     srcs = [],
@@ -21,4 +23,41 @@ py_binary(
     name = "deflate_compress",
     srcs = ["deflate_compress.py"],
     visibility = ["//:__subpackages__"],
+)
+
+lcov(
+    name = "lcov_list",
+    instrumented_targets = [
+        "//huffman",
+        "//src:decompress",
+    ],
+    lcov_opts = [
+        "--rc lcov_branch_coverage=1",
+        "--list",
+    ],
+    test_targets = [
+        "//huffman/test/...",
+        "//src/test/...",
+    ],
+)
+
+lcov(
+    name = "lcov_html",
+    instrumented_targets = [
+        "//huffman",
+        "//src:decompress",
+    ],
+    lcov_opts = [
+        "--show-details",
+        "--keep-descriptions",
+        "--branch-coverage",
+        "--highlight",
+        "--missed",
+        "--dark-mode",
+    ],
+    lcov_tool = "genhtml",
+    test_targets = [
+        "//huffman/test/...",
+        "//src/test/...",
+    ],
 )

--- a/tools/lcov.bzl
+++ b/tools/lcov.bzl
@@ -1,0 +1,122 @@
+"""
+Rule for generating a coverage report
+"""
+
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@local_config_info//:defs.bzl", "BAZEL_BIN")
+
+def lcov(
+        name,
+        instrumented_targets = [],
+        test_targets = [],
+        coverage_opts = [
+            "--combined_report=lcov",
+            "--experimental_generate_llvm_lcov",
+            "--test_output=errors",
+            # https://github.com/bazelbuild/bazel/issues/13919
+            "--test_env=COVERAGE_GCOV_OPTIONS=-b",
+        ],
+        lcov_tool = "lcov",
+        lcov_opts = []):
+    """
+    Generate an lcov reports from the output of Bazel's coverage command.
+
+    Args:
+      name: string
+        Name for `lcov` rule.
+      instrumented_targets: string_list
+        List of targets for which to determine coverage.
+      test_targets: string_list
+        List of targets used to determine coverage.
+      coverage_opts: string_list
+        Options passed to Bazel's coverage command.
+      lcov_tool: string
+        lcov tool to use. See `@lcov//:bin/` for a complete list
+      lcov_opts: string_list
+        Options passed to the lcov tool to generate a report.
+
+    `instrumented_targets` and `test_targets` are specified as strings which
+    are passed to the underlying coverage command, and may include wildcards.
+
+    If `lcov_tool` is set to `genhtml`, the output directory is set to `$(bazel
+    info output_path)/lcov_html` and the target will attempt to open the html
+    page.
+
+    Example:
+
+      lcov(
+        name = "lcov_list",
+        instrumented_targets = ["//:skytest"],
+        test_targets = ["//test/..."],
+        lcov_opts = ["--rc lcov_branch_coverage=1", "--list"],
+      )
+
+      bazel run :lcov_list
+
+      lcov(
+        name = "lcov_html",
+        instrumented_targets = ["//:skytest"],
+        test_targets = ["//test/..."],
+        lcov_tool = "genhtml",
+      )
+
+      bazel run :lcov_html
+    """
+    instrumented = [
+        "--instrumentation_filter={}".format(target)
+        for target in instrumented_targets
+    ]
+
+    coverage_command = " ".join(
+        ["{bazel} coverage {bazel_common_opts}"] +
+        coverage_opts + instrumented + test_targets,
+    )
+
+    open_command = ""
+
+    if lcov_tool == "genhtml":
+        output_dir = "\"${{output_path}}/lcov_html\""
+        lcov_opts = ["--output {}".format(output_dir)] + lcov_opts
+        open_command = "xdg-open {}/index.html".format(output_dir)
+
+    lcov_command = " ".join(["\"${{lcov_tool}}\""] + lcov_opts)
+
+    content = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "",
+        "lcov_tool=\"$(pwd)/${{1}}\"",
+        "",
+        "cd $BUILD_WORKSPACE_DIRECTORY",
+        "output_path=\"$({bazel} info {bazel_common_opts} output_path)\"",
+        "coverage_report=\"${{output_path}}/_coverage/_coverage_report.dat\"",
+        "",
+        coverage_command + " || true",
+        "",
+        lcov_command + " \"${{coverage_report}}\"",
+        open_command,
+    ]
+
+    content = [
+        line.format(
+            bazel = BAZEL_BIN,
+            bazel_common_opts = "--color=yes --curses=yes",
+        )
+        for line in content
+    ]
+
+    write_file(
+        name = "gen_" + name,
+        out = name + ".sh",
+        content = content,
+        is_executable = True,
+        tags = ["manual"],
+        visibility = ["//visibility:private"],
+    )
+
+    native.sh_binary(
+        name = name,
+        srcs = [name + ".sh"],
+        data = ["@lcov//:bin/{}".format(lcov_tool)],
+        args = ["$(rootpath @lcov//:bin/{})".format(lcov_tool)],
+    )

--- a/tools/local_config_info.bzl
+++ b/tools/local_config_info.bzl
@@ -7,11 +7,32 @@ def _local_config_info_impl(rctx):
 
     external = str(rctx.path(".").realpath).removesuffix("/" + rctx.name)
 
+    env = rctx.execute(["env"]).stdout.splitlines()
+
+    def env_var(pattern):
+        values = [
+            line.removeprefix(pattern)
+            for line in env
+            if line.startswith(pattern)
+        ]
+
+        if len(values) > 1:
+            fail()
+
+        return values[0] if values else None
+
+    bazel_bin = env_var("_=")
+
     rctx.file(
         "defs.bzl",
         executable = False,
-        content = """BAZEL_EXTERNAL_DIR = "{}"
-              """.format(external),
+        content = """
+BAZEL_BIN = "{}"
+BAZEL_EXTERNAL_DIR = "{}"
+              """.format(
+            bazel_bin,
+            external,
+        ),
     )
 
 local_config_info = repository_rule(


### PR DESCRIPTION
Use Clang when generating coverage data. It is faster than GCC and
reports higher branch coverage.

Coverage reports are now generated with `lcov` rules and CI is updated
to use `//tools:lcov_list`.

Change-Id: I84311f28070a13520684349e8e4ebfb538a7d002