### PR TITLE
remove chucnked output for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,20 @@ Otherwise, copy the clangd args from the [.vscode/settings.json](.vscode/setting
 
 ### TODO
 
-* Get SYCL building with bazel. Already have OpenSYCL building for CPU only [here](https://github.com/garymm/xpu).
-  Would be nicer to use [intel's LLVM](https://github.com/intel/llvm) which supports lots of GPUs.
-* (maybe?) Implement LZ77 with C++ std lib.
+#### Basic
+
 * Implement Deflate decompression with C++ std lib.
-* Port Deflate to SYCL.
 * Benchmark it on CPU.
 * Build system work to get it to run on GPU.
+* Port Deflate to GPU.
 * Benchmark it on GPU.
+
+#### Nice to have
+
+* Support chunked output. Started in
+  [2e6a83d622e](https://github.com/garymm/starflate/commit/2e6a83d622a0bbe6b65c757199b64511156b516c)
+  , but removed because it was adding too much complexity and I wanted to focus on getting the
+  basics working.
 
 ## References
 

--- a/src/decompress.cpp
+++ b/src/decompress.cpp
@@ -15,16 +15,16 @@ auto valid(BlockType type) -> bool
 }
 
 auto read_header(huffman::bit_span& compressed_bits)
-    -> std::expected<BlockHeader, DecompressError>
+    -> std::expected<BlockHeader, DecompressStatus>
 {
   if (std::ranges::size(compressed_bits) < 3) {
-    return std::unexpected{DecompressError::InvalidBlockHeader};
+    return std::unexpected{DecompressStatus::InvalidBlockHeader};
   }
   auto type = static_cast<BlockType>(
       std::uint8_t{static_cast<bool>(compressed_bits[1])} |
       (std::uint8_t{static_cast<bool>(compressed_bits[2])} << 1));
   if (not valid(type)) {
-    return std::unexpected{DecompressError::InvalidBlockHeader};
+    return std::unexpected{DecompressStatus::InvalidBlockHeader};
   }
   const bool final{static_cast<bool>(compressed_bits[0])};
   compressed_bits.consume(3);
@@ -34,16 +34,16 @@ auto read_header(huffman::bit_span& compressed_bits)
 }  // namespace detail
 
 auto decompress(std::span<const std::byte> src, std::span<std::byte> dst)
-    -> std::expected<DecompressResult, DecompressError>
+    -> DecompressStatus
 {
   using enum detail::BlockType;
 
   huffman::bit_span src_bits{src};
-  std::size_t dst_written{};
+  // std::size_t dst_written{};
   for (bool was_final = false; not was_final;) {
     const auto header = detail::read_header(src_bits);
     if (not header) {
-      return std::unexpected{header.error()};
+      return header.error();
     }
     was_final = header->final;
     if (header->type == NoCompression) {  // no compression
@@ -52,7 +52,7 @@ auto decompress(std::span<const std::byte> src, std::span<std::byte> dst)
       const std::uint16_t len = src_bits.pop_16();
       const std::uint16_t nlen = src_bits.pop_16();
       if (len != static_cast<std::uint16_t>(~nlen)) {
-        return std::unexpected{DecompressError::NoCompressionLenMismatch};
+        return DecompressStatus::NoCompressionLenMismatch;
       }
       // TODO: should we return an error instead of assert?
       assert(
@@ -60,24 +60,24 @@ auto decompress(std::span<const std::byte> src, std::span<std::byte> dst)
               src_bits.size(), std::size_t{len} * CHAR_BIT) and
           "not enough bits in src");
 
-      if (std::ranges::size(dst) < len) {
-        return DecompressResult{src, dst_written, len};
+      if (dst.size() < len) {
+        return DecompressStatus::DstTooSmall;
       }
 
       std::copy_n(src_bits.byte_data(), len, dst.begin());
       src_bits.consume(CHAR_BIT * len);
       dst = dst.subspan(len);
-      dst_written += len;
+      // dst_written += len;
     } else {
       // TODO: implement
-      return std::unexpected{DecompressError::Error};
+      return DecompressStatus::Error;
     }
     const auto distance =
         std::distance(std::ranges::data(src), src_bits.byte_data());
     assert(distance >= 0 and "distance must be positive");
     src = src.subspan(static_cast<size_t>(distance));
   }
-  return DecompressResult{src, dst_written, 0};
+  return DecompressStatus::Success;
 }
 
 }  // namespace starflate

--- a/src/decompress.hpp
+++ b/src/decompress.hpp
@@ -10,11 +10,13 @@
 namespace starflate {
 
 // error code enum
-enum class DecompressError : std::uint8_t
+enum class DecompressStatus : std::uint8_t
 {
-  Error,
+  Success,
+  Error,  // TODO: remove
   InvalidBlockHeader,
   NoCompressionLenMismatch,
+  DstTooSmall,
 };
 
 namespace detail {
@@ -33,31 +35,17 @@ struct BlockHeader
 };
 
 auto read_header(huffman::bit_span& compressed_bits)
-    -> std::expected<BlockHeader, DecompressError>;
+    -> std::expected<BlockHeader, DecompressStatus>;
 }  // namespace detail
-
-/// The result of decompress.
-///
-struct DecompressResult
-{
-  std::span<const std::byte> remaining_src;  ///< Remaining source data after
-                                             ///< decompression.
-  std::size_t dst_written;        ///< Number of bytes written to dst.
-  std::size_t min_next_dst_size;  ///< Minimum number of bytes required in dst
-                                  ///< for the next decompression. This is only
-                                  ///< enough space for decompression of a
-                                  ///< single block
-};
 
 /// Decompresses the given source data into the destination buffer.
 ///
 /// @param src The source data to decompress.
 /// @param dst The destination buffer to store the decompressed data.
-/// @return An expected value containing the decompression result if successful,
-/// or an error code if failed.
+/// @return A status code indicating the result of the decompression.
 ///
 auto decompress(std::span<const std::byte> src, std::span<std::byte> dst)
-    -> std::expected<DecompressResult, DecompressError>;
+    -> DecompressStatus;
 
 template <std::ranges::contiguous_range R>
   requires std::same_as<std::ranges::range_value_t<R>, std::byte>


### PR DESCRIPTION
remove chucnked output for now

It adds too much complexity. I want to focus on the basics.

Change-Id: I45c0da75d8a3c81eb20a982c8ccba6a1c87b2374